### PR TITLE
Hide public source labels

### DIFF
--- a/addon/lib/configuration.js
+++ b/addon/lib/configuration.js
@@ -1,6 +1,22 @@
 import { TorrentProvider, SortType, SizeLimit } from './types.js';
 
-// ─── Pre-built Configurations ─────────────────────────────────────────────────
+const PublicProviderAliases = {
+  s1: TorrentProvider.YTS,
+  s2: TorrentProvider.EZTV,
+  s3: TorrentProvider.RARBG,
+  s4: TorrentProvider.TORRENTGALAXY,
+  s5: TorrentProvider.THEPIRATEBAY,
+  s6: TorrentProvider.KICKASSTORRENTS,
+  s7: TorrentProvider.LEETX,
+  s8: TorrentProvider.NYAA,
+  s9: TorrentProvider.ANIMESATURN,
+  s10: TorrentProvider.RUTOR,
+  s11: TorrentProvider.RUTRACKER,
+  s12: TorrentProvider.LIMETORRENTS,
+  s13: TorrentProvider.BITSEARCH,
+};
+
+// Pre-built Configurations
 
 export const PreConfigurations = {
   lite: {
@@ -60,7 +76,7 @@ export function parseConfiguration(configString) {
 
     switch (key.toLowerCase()) {
       case 'providers':
-        config.providers = value.toLowerCase().split(',').filter(Boolean);
+        config.providers = value.toLowerCase().split(',').filter(Boolean).map(normalizeProvider);
         break;
       case 'sort':
         config.sort = value.toLowerCase();
@@ -138,7 +154,7 @@ export function getManifestOverride(configString) {
   };
 }
 
-// ─── Defaults ─────────────────────────────────────────────────────────────────
+// Defaults
 
 export function getDefaultConfiguration() {
   return {
@@ -170,6 +186,10 @@ function parseBoolean(value, fallback = false) {
   if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
   if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
   return fallback;
+}
+
+function normalizeProvider(provider) {
+  return PublicProviderAliases[provider] ?? provider;
 }
 
 function clampPrewarmLimit(value, fallback = 3) {

--- a/addon/lib/landingTemplate.js
+++ b/addon/lib/landingTemplate.js
@@ -1,18 +1,22 @@
 const PROVIDERS = [
-  ['yts', 'YTS'],
-  ['eztv', 'EZTV'],
-  ['rarbg', 'RARBG'],
-  ['torrentgalaxy', 'TorrentGalaxy'],
-  ['thepiratebay', 'The Pirate Bay'],
-  ['kickasstorrents', 'KickassTorrents'],
-  ['1337x', '1337x'],
-  ['nyaa', 'Nyaa'],
-  ['animesaturn', 'AnimeSaturn'],
-  ['rutor', 'Rutor'],
-  ['rutracker', 'Rutracker'],
-  ['limetorrents', 'LimeTorrents'],
-  ['bitsearch', 'Bitsearch'],
+  ['s1', 'Source 1', 'yts'],
+  ['s2', 'Source 2', 'eztv'],
+  ['s3', 'Source 3', 'rarbg'],
+  ['s4', 'Source 4', 'torrentgalaxy'],
+  ['s5', 'Source 5', 'thepiratebay'],
+  ['s6', 'Source 6', 'kickasstorrents'],
+  ['s7', 'Source 7', '1337x'],
+  ['s8', 'Source 8', 'nyaa'],
+  ['s9', 'Source 9', 'animesaturn'],
+  ['s10', 'Source 10', 'rutor'],
+  ['s11', 'Source 11', 'rutracker'],
+  ['s12', 'Source 12', 'limetorrents'],
+  ['s13', 'Source 13', 'bitsearch'],
 ];
+
+const PROVIDER_TO_PUBLIC_CODE = Object.fromEntries(
+  PROVIDERS.map(([code, _label, provider]) => [provider, code])
+);
 
 const QUALITIES = [
   ['4k', '4K'],
@@ -56,7 +60,7 @@ const DEBRID_FIELDS = [
  */
 export function landingTemplate(manifest, initialConfig = {}) {
   const initialState = escapeJsonForHtml({
-    providers: initialConfig.providers ?? [],
+    providers: (initialConfig.providers ?? []).map(provider => PROVIDER_TO_PUBLIC_CODE[provider] ?? provider),
     sort: initialConfig.sort ?? 'qualityseeders',
     limit: initialConfig.limit ?? 10,
     qualities: initialConfig.qualities ?? [],
@@ -385,7 +389,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
       <section class="panel hero">
         <span class="eyebrow">Magnetio for Stremio</span>
         <h1>Build the exact addon URL you actually want.</h1>
-        <p>Pick providers, tune stream ranking, set subtitle preferences and plug in your debrid stack. The result is a Stremio manifest URL that is ready to install as-is.</p>
+        <p>Pick sources, tune stream ranking, set subtitle preferences and plug in your debrid stack. The result is a Stremio manifest URL that is ready to install as-is.</p>
         <div class="badges">
           <span class="badge">Torrent aggregation</span>
           <span class="badge">Multi-debrid direct links</span>
@@ -394,7 +398,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
       </section>
 
       <section class="panel section">
-        <h2>Providers</h2>
+        <h2>Sources</h2>
         <p>Balance breadth against noise. You can keep the broad net or trim this down to the sources you trust most.</p>
         <div class="provider-grid" id="providerGrid">
           ${PROVIDERS.map(([value, label]) => `<button class="provider-chip" type="button" data-provider="${value}">${label}</button>`).join('')}

--- a/addon/lib/manifest.js
+++ b/addon/lib/manifest.js
@@ -6,12 +6,6 @@ const ADDON_VERSION = '1.1.5';
 const ADDON_NAME    = 'Magnetio';
 const ADDON_LOGO    = 'https://i.imgur.com/magnetio.png';
 
-const PROVIDERS_DESCRIPTION = [
-  'YTS', 'EZTV', 'RARBG', 'TorrentGalaxy', 'ThePirateBay',
-  'KickassTorrents', '1337x', 'Nyaa', 'AnimeSaturn', 'Rutor', 'Rutracker',
-  'LimeTorrents', 'Bitsearch',
-].join(', ');
-
 /**
  * Build the full addon manifest for a given config.
  */
@@ -44,7 +38,7 @@ export function dummyManifest() {
     id:          ADDON_ID,
     version:     ADDON_VERSION,
     name:        ADDON_NAME,
-    description: `${ADDON_NAME} – configure providers, subtitles and debrid services at /configure`,
+    description: `${ADDON_NAME} - configure sources, subtitles and debrid services at /configure`,
     logo:        ADDON_LOGO,
     background:  'https://i.imgur.com/magnetio-bg.jpg',
     types:       ['movie', 'series', 'anime'],
@@ -71,7 +65,7 @@ function getDescription(config) {
     ? `\nDebrid services: ${enabledMochs.map(m => m.name).join(', ')}.`
     : '';
   return (
-    `Aggregates torrents from: ${PROVIDERS_DESCRIPTION}. Includes OpenSubtitles-powered subtitle support when configured server-side.` +
+    `Aggregates streams from configurable sources. Includes OpenSubtitles-powered subtitle support when configured server-side.` +
     debridPart +
     `\n\nConfigure at your Stremio settings page.`
   );
@@ -81,8 +75,8 @@ function getCatalogs(config) {
   return getEnabledMochs(config).flatMap(moch =>
     moch.hasCatalog
       ? [
-          { id: `${moch.id}_movie`,  type: 'movie',  name: `${moch.name} – Movies`  },
-          { id: `${moch.id}_series`, type: 'series', name: `${moch.name} – Series` },
+          { id: `${moch.id}_movie`,  type: 'movie',  name: `${moch.name} - Movies`  },
+          { id: `${moch.id}_series`, type: 'series', name: `${moch.name} - Series` },
         ]
       : []
   );

--- a/addon/lib/streamInfo.js
+++ b/addon/lib/streamInfo.js
@@ -12,7 +12,6 @@ export function toStreamInfo(record, config) {
   const langs      = (record.languages ?? []).map(getLanguageFlag).join('');
   const sizeStr    = record.size ? formatSize(record.size) : '';
   const seedersStr = record.seeders != null ? `👥 ${record.seeders}` : '';
-  const provStr    = record.provider ? `[${record.provider}]` : '';
   const sourceStr  = [record.source, record.codec, record.hdr ? 'HDR' : null].filter(Boolean).join(' · ');
   const filename   = record.fileName || record.title || record.name;
 
@@ -20,7 +19,7 @@ export function toStreamInfo(record, config) {
   const description = [
     record.title || record.name,
     sourceStr,
-    [seedersStr, sizeStr, provStr].filter(Boolean).join(' '),
+    [seedersStr, sizeStr].filter(Boolean).join(' '),
   ].filter(Boolean).join('\n');
 
   const stream = {

--- a/addon/test/sdk-upgrade.test.js
+++ b/addon/test/sdk-upgrade.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import { parseConfiguration } from '../lib/configuration.js';
 import { manifest, dummyManifest } from '../lib/manifest.js';
+import { landingTemplate } from '../lib/landingTemplate.js';
 import { buildSubtitleSearchParams, resolveSubtitleLanguages } from '../lib/subtitles.js';
 import { applyFilters } from '../lib/filter.js';
 import { toSubtitleLanguageCode } from '../lib/languages.js';
@@ -17,6 +18,12 @@ test('configuration parser supports subtitle languages', () => {
   assert.deepEqual(config.providers, ['yts', 'eztv']);
   assert.deepEqual(config.subtitleLanguages, ['en', 'es']);
   assert.equal(config.limit, 20);
+});
+
+test('public provider aliases map to internal providers', () => {
+  const config = parseConfiguration('providers=s1,s2,s7');
+
+  assert.deepEqual(config.providers, ['yts', 'eztv', '1337x']);
 });
 
 test('configuration parser supports debrid prewarm controls', () => {
@@ -52,6 +59,15 @@ test('dummy manifest advertises configurable subtitles-enabled addon surface', (
   assert.equal(rootManifest.behaviorHints.configurable, true);
   assert.equal(rootManifest.behaviorHints.p2p, true);
   assert.ok(rootManifest.resources.some(resource => resource.name === 'subtitles'));
+});
+
+test('configuration page hides provider brand names', () => {
+  const html = landingTemplate(dummyManifest(), parseConfiguration('providers=yts,eztv,1337x'));
+
+  assert.match(html, /Source 1/);
+  assert.match(html, /Source 2/);
+  assert.match(html, /"providers":\["s1","s2","s7"\]/);
+  assert.doesNotMatch(html, /YTS|EZTV|1337x|The Pirate Bay|KickassTorrents|TorrentGalaxy/);
 });
 
 test('configured manifest exposes subtitle resource and p2p hint', () => {


### PR DESCRIPTION
## Summary
- Replace public provider names in the configuration UI with neutral Source labels
- Generate public manifest URLs with source aliases while preserving existing provider parsing
- Remove provider names from public manifest and stream descriptions

## Validation
- npm test