### PR TITLE
Use self-hosted production deployment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /addon
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /scraper
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,13 +10,21 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
 jobs:
   validate:
+    name: validate
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -40,38 +48,39 @@ jobs:
         run: npm ci
 
   deploy:
+    name: deploy
     needs: validate
     if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, raspberry-pi, production]
     environment: production
+    timeout-minutes: 20
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
-      - name: Configure SSH
-        env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
-          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+      - name: Verify production runner
         run: |
           set -euo pipefail
-          PORT="${DEPLOY_PORT:-22}"
 
-          mkdir -p ~/.ssh
-          printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -p "$PORT" "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+          test "${RUNNER_ENVIRONMENT:-}" = "self-hosted"
+          command -v rsync
+          docker compose version
 
-      - name: Sync repository to server
+      - name: Sync repository to local deploy path
         env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
-          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: /srv/magnetio
         run: |
           set -euo pipefail
-          PORT="${DEPLOY_PORT:-22}"
+
+          if [ "$DEPLOY_PATH" != "/srv/magnetio" ]; then
+            echo "Unexpected DEPLOY_PATH: $DEPLOY_PATH"
+            exit 1
+          fi
+
+          mkdir -p "$DEPLOY_PATH"
 
           rsync -az --delete \
             --filter='P .env' \
@@ -82,20 +91,12 @@ jobs:
             --exclude 'addon/node_modules/' \
             --exclude 'scraper/node_modules/' \
             --exclude '.DS_Store' \
-            -e "ssh -p $PORT" \
-            ./ "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH/"
+            ./ "$DEPLOY_PATH/"
 
       - name: Deploy with Docker Compose
         env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
-          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: /srv/magnetio
         run: |
-          set -euo pipefail
-          PORT="${DEPLOY_PORT:-22}"
-
-          ssh -p "$PORT" "$DEPLOY_USER@$DEPLOY_HOST" "DEPLOY_PATH='$DEPLOY_PATH' bash -s" <<'EOF'
           set -euo pipefail
 
           cd "$DEPLOY_PATH"
@@ -107,7 +108,6 @@ jobs:
 
           docker compose up -d --build --remove-orphans
           docker compose ps
-          EOF
 
       - name: Health check
         env:


### PR DESCRIPTION
This pull request updates the CI/CD pipeline configuration to improve automation, reliability, and maintainability. The main changes include adding Dependabot for automated dependency updates and refactoring the deployment workflow to run on a self-hosted production runner, simplifying the deploy process by removing SSH-based remote deployment in favor of local deployment on the runner.

**CI/CD Automation and Dependency Management:**

* Added a `.github/dependabot.yml` configuration to enable automated dependency updates for GitHub Actions and both `addon` and `scraper` npm packages.

**Deployment Workflow Refactor:**

* Updated `.github/workflows/deploy.yml` to add concurrency control, explicit job names, and timeouts for both `validate` and `deploy` jobs for improved reliability. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R13-R27) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R51-R83)
* Changed the deployment job to run on a self-hosted Raspberry Pi production runner instead of a remote SSH target, and removed all SSH and remote server configuration steps.
* Simplified the deployment process by syncing the repository directly to a local path (`/srv/magnetio`) on the runner and running Docker Compose locally, eliminating the need for remote commands. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R51-R83) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L85-L99) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L110)