### PR TITLE
Use home directory deploy path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,11 +71,11 @@ jobs:
 
       - name: Sync repository to local deploy path
         env:
-          DEPLOY_PATH: /srv/magnetio
+          DEPLOY_PATH: /home/peterdsp/magnetio
         run: |
           set -euo pipefail
 
-          if [ "$DEPLOY_PATH" != "/srv/magnetio" ]; then
+          if [ "$DEPLOY_PATH" != "/home/peterdsp/magnetio" ]; then
             echo "Unexpected DEPLOY_PATH: $DEPLOY_PATH"
             exit 1
           fi
@@ -95,7 +95,7 @@ jobs:
 
       - name: Deploy with Docker Compose
         env:
-          DEPLOY_PATH: /srv/magnetio
+          DEPLOY_PATH: /home/peterdsp/magnetio
         run: |
           set -euo pipefail
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ Do not merge or enable auto-merge for a pull request unless:
 
 ## Secrets
 
-This repository is public. Real secrets must stay only on the production host in `/srv/magnetio/.env` and related local env files.
+This repository is public. Real secrets must stay only on the production host in `/home/peterdsp/magnetio/.env` and related local env files.
 
 Never commit:
 


### PR DESCRIPTION
## Summary
- Change production deploy path to /home/peterdsp/magnetio so the self-hosted runner can deploy without sudo
- Update the security policy secret location to match

## Validation
- git diff --check