### PR TITLE
Add providers and automatic domain failover

### DIFF
--- a/scraper/lib/domainRotation.js
+++ b/scraper/lib/domainRotation.js
@@ -1,0 +1,99 @@
+import { logger } from './logger.js';
+
+const domainHealth = new Map();
+const COOLDOWN_MS = 5 * 60 * 1000;
+
+function isHealthy(domain) {
+  const entry = domainHealth.get(domain);
+  if (!entry) return true;
+  if (Date.now() - entry.failedAt > COOLDOWN_MS) {
+    domainHealth.delete(domain);
+    return true;
+  }
+  return false;
+}
+
+function markFailed(domain) {
+  domainHealth.set(domain, { failedAt: Date.now() });
+}
+
+function markHealthy(domain) {
+  domainHealth.delete(domain);
+}
+
+export async function tryDomains(domains, requestFn, providerName) {
+  const healthy = domains.filter(isHealthy);
+  const candidates = healthy.length > 0 ? healthy : domains;
+
+  for (const domain of candidates) {
+    try {
+      const result = await requestFn(domain);
+      markHealthy(domain);
+      return result;
+    } catch (err) {
+      const status = err.response?.status;
+      const isBadDomain = !status || status >= 500 || status === 403;
+      if (isBadDomain) {
+        markFailed(domain);
+        logger.debug(`[${providerName}] domain ${domain} failed (${status ?? err.code ?? err.message}), trying next`);
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  throw new Error(`[${providerName}] all domains exhausted`);
+}
+
+export const UNBLOCKIT = 'unblockit.download';
+
+export const PROVIDER_DOMAINS = {
+  '1337x': [
+    'https://1337x.to',
+    'https://1337x.st',
+    'https://1337x.gd',
+    `https://1337x.${UNBLOCKIT}`,
+  ],
+  eztv: [
+    'https://eztv.re',
+    'https://eztvx.to',
+    `https://eztv.${UNBLOCKIT}`,
+  ],
+  limetorrents: [
+    'https://www.limetorrents.fun',
+    'https://www.limetorrents.lol',
+    `https://limetorrents.${UNBLOCKIT}`,
+  ],
+  kickasstorrents: [
+    'https://katcr.to',
+    'https://kickasstorrents.to',
+    `https://kickasstorrents.${UNBLOCKIT}`,
+  ],
+  torrentgalaxy: [
+    'https://torrentgalaxy.one',
+    'https://torrentgalaxy.to',
+    `https://torrentgalaxy.${UNBLOCKIT}`,
+  ],
+  yts: [
+    'https://yts.do',
+    'https://yts.mx',
+    `https://yts.${UNBLOCKIT}`,
+  ],
+  thepiratebay: [
+    'https://apibay.org',
+    'https://thepiratebay.org',
+    `https://thepiratebay.${UNBLOCKIT}`,
+  ],
+  glotorrents: [
+    'https://glodls.to',
+    'https://gtso.cc',
+  ],
+  torlock: [
+    'https://torlock2.com',
+    'https://torlock.com',
+  ],
+  torrentdownloads: [
+    'https://torrentdownload.info',
+    'https://torrentdownloads.pro',
+  ],
+};

--- a/scraper/providers/bt4g.js
+++ b/scraper/providers/bt4g.js
@@ -1,0 +1,86 @@
+/**
+ * BT4G provider -- scrapes bt4gprx.com search results via HTML.
+ * Supports movies and series.
+ */
+import * as cheerio from 'cheerio';
+import { get } from '../lib/httpClient.js';
+import { parseTitle, buildSearchQuery } from '../lib/titleHelper.js';
+import { logger } from '../lib/logger.js';
+
+const BASE = 'https://bt4gprx.com';
+
+export const id   = 'bt4g';
+export const name = 'BT4G';
+
+export async function scrape(meta) {
+  if (!meta?.name) return [];
+
+  try {
+    const query = buildSearchQuery(meta);
+    const url   = `${BASE}/search/${encodeURIComponent(query)}/byseeders/1`;
+
+    const { data } = await get(url, { limiterKey: 'bt4g' });
+    const $ = cheerio.load(data);
+    const results = [];
+
+    $('div.search-ret-item, div.one-result').each((_, el) => {
+      const $el = $(el);
+
+      const titleEl = $el.find('h5 a, a.item-title').first();
+      const title = titleEl.text().trim();
+      if (!title) return;
+
+      const magnetEl = $el.find('a[href^="magnet:"]').first();
+      const magnet = magnetEl.attr('href') ?? '';
+      const infoHash = extractInfoHash(magnet);
+      if (!infoHash) return;
+
+      const statsText = $el.text();
+      const seeders  = extractNumber(statsText, /(\d+)\s*seeder/i);
+      const leechers = extractNumber(statsText, /(\d+)\s*leecher/i);
+      const sizeText = $el.find('span:contains("B")').first().text().trim()
+                    || extractSizeText(statsText);
+      const size = parseSize(sizeText);
+
+      results.push({
+        infoHash,
+        title,
+        seeders,
+        leechers,
+        size,
+        provider: 'BT4G',
+        imdbId: meta.imdbId,
+        ...parseTitle(title),
+      });
+    });
+
+    return results;
+  } catch (err) {
+    logger.warn(`[BT4G] ${err.message}`);
+    return [];
+  }
+}
+
+function extractInfoHash(magnet) {
+  const match = magnet.match(/xt=urn:btih:([a-fA-F0-9]{40}|[a-zA-Z2-7]{32})/i);
+  return match ? match[1].toLowerCase() : null;
+}
+
+function extractNumber(text, pattern) {
+  const m = text.match(pattern);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
+function extractSizeText(text) {
+  const m = text.match(/([\d.]+)\s*(B|KB|MB|GB|TB)/i);
+  return m ? m[0] : '';
+}
+
+function parseSize(str) {
+  if (!str) return 0;
+  const m = str.match(/([\d.]+)\s*(B|KB|MB|GB|TB)/i);
+  if (!m) return 0;
+  const val   = parseFloat(m[1]);
+  const units = { b: 1, kb: 1024, mb: 1024 ** 2, gb: 1024 ** 3, tb: 1024 ** 4 };
+  return Math.round(val * (units[m[2].toLowerCase()] ?? 1));
+}

--- a/scraper/providers/btdig.js
+++ b/scraper/providers/btdig.js
@@ -1,0 +1,84 @@
+/**
+ * BTDig provider -- scrapes btdig.com search results via HTML.
+ * DHT search engine, good for finding less common torrents.
+ */
+import * as cheerio from 'cheerio';
+import { get } from '../lib/httpClient.js';
+import { parseTitle, buildSearchQuery } from '../lib/titleHelper.js';
+import { logger } from '../lib/logger.js';
+
+const BASE = 'https://btdig.com';
+
+export const id   = 'btdig';
+export const name = 'BTDig';
+
+export async function scrape(meta) {
+  if (!meta?.name) return [];
+
+  try {
+    const query = buildSearchQuery(meta);
+    const url   = `${BASE}/search`;
+
+    const { data } = await get(url, {
+      limiterKey: 'btdig',
+      params: { q: query, order: 0 },
+    });
+
+    const $ = cheerio.load(data);
+    const results = [];
+
+    $('div.one_result').each((_, el) => {
+      const $el = $(el);
+
+      const titleEl = $el.find('div.torrent_name a').first();
+      const title = titleEl.text().trim();
+      if (!title) return;
+
+      const href = titleEl.attr('href') ?? '';
+      const infoHash = extractHashFromUrl(href);
+      if (!infoHash) return;
+
+      const statsText = $el.find('div.torrent_stats, span.torrent_size').text();
+      const size = parseSize(statsText);
+
+      const magnetEl = $el.find('a[href^="magnet:"]').first();
+      const magnet = magnetEl.attr('href') ?? '';
+      const magnetHash = extractInfoHash(magnet) ?? infoHash;
+
+      results.push({
+        infoHash: magnetHash,
+        title,
+        seeders: 0,
+        leechers: 0,
+        size,
+        provider: 'BTDig',
+        imdbId: meta.imdbId,
+        ...parseTitle(title),
+      });
+    });
+
+    return results;
+  } catch (err) {
+    logger.warn(`[BTDig] ${err.message}`);
+    return [];
+  }
+}
+
+function extractHashFromUrl(url) {
+  const match = url.match(/([a-fA-F0-9]{40})/i);
+  return match ? match[1].toLowerCase() : null;
+}
+
+function extractInfoHash(magnet) {
+  const match = magnet.match(/xt=urn:btih:([a-fA-F0-9]{40}|[a-zA-Z2-7]{32})/i);
+  return match ? match[1].toLowerCase() : null;
+}
+
+function parseSize(str) {
+  if (!str) return 0;
+  const m = str.match(/([\d.]+)\s*(B|KB|MB|GB|TB)/i);
+  if (!m) return 0;
+  const val   = parseFloat(m[1]);
+  const units = { b: 1, kb: 1024, mb: 1024 ** 2, gb: 1024 ** 3, tb: 1024 ** 4 };
+  return Math.round(val * (units[m[2].toLowerCase()] ?? 1));
+}

--- a/scraper/providers/eztv.js
+++ b/scraper/providers/eztv.js
@@ -1,12 +1,13 @@
 /**
- * EZTV provider — uses the official EZTV JSON API.
+ * EZTV provider -- uses the official EZTV JSON API.
  * Supports series only (no movies).
  */
 import { get } from '../lib/httpClient.js';
 import { parseTitle } from '../lib/titleHelper.js';
+import { tryDomains, PROVIDER_DOMAINS } from '../lib/domainRotation.js';
 import { logger } from '../lib/logger.js';
 
-const BASE = 'https://eztv.re/api';
+const DOMAINS = PROVIDER_DOMAINS.eztv;
 
 export const id   = 'eztv';
 export const name = 'EZTV';
@@ -22,18 +23,20 @@ export async function scrape(meta) {
     const results = [];
 
     while (true) {
-      const { data } = await get(`${BASE}/get-torrents`, {
-        limiterKey: 'eztv',
-        responseType: 'json',
-        params: { imdb_id: imdbNumeric, limit: 100, page },
-      });
+      const { data } = await tryDomains(DOMAINS, async (base) => {
+        return get(`${base}/api/get-torrents`, {
+          limiterKey: 'eztv',
+          responseType: 'json',
+          params: { imdb_id: imdbNumeric, limit: 100, page },
+        });
+      }, 'EZTV');
 
       const torrents = data?.torrents ?? [];
       results.push(...torrents.map(normalise));
 
       if (torrents.length < 100) break;
       page++;
-      if (page > 5) break; // cap at 500 results
+      if (page > 5) break;
     }
 
     return filterBySeason(results, meta.season, meta.episode);

--- a/scraper/providers/glotorrents.js
+++ b/scraper/providers/glotorrents.js
@@ -1,5 +1,5 @@
 /**
- * TorrentGalaxy provider -- scrapes search results via HTML.
+ * GloTorrents provider -- scrapes glodls.to search results via HTML.
  */
 import * as cheerio from 'cheerio';
 import { get } from '../lib/httpClient.js';
@@ -7,51 +7,54 @@ import { parseTitle, buildSearchQuery } from '../lib/titleHelper.js';
 import { tryDomains, PROVIDER_DOMAINS } from '../lib/domainRotation.js';
 import { logger } from '../lib/logger.js';
 
-const DOMAINS = PROVIDER_DOMAINS.torrentgalaxy;
+const DOMAINS = PROVIDER_DOMAINS.glotorrents;
 
-export const id   = 'torrentgalaxy';
-export const name = 'TorrentGalaxy';
+export const id   = 'glotorrents';
+export const name = 'GloTorrents';
 
 export async function scrape(meta) {
   if (!meta?.name) return [];
 
   try {
     const query = buildSearchQuery(meta);
-    const cat   = meta.type === 'movie' ? '3' : '41';
+    const cat   = meta.type === 'movie' ? '1' : '41';
 
     const { data } = await tryDomains(DOMAINS, async (base) => {
-      return get(`${base}/torrents.php`, {
-        limiterKey: 'torrentgalaxy',
+      return get(`${base}/search_results.php`, {
+        limiterKey: 'glotorrents',
         params: {
           search: query,
           cat,
+          incldead: 0,
+          inclexternal: 0,
           lang: 0,
-          nox: 1,
           sort: 'seeders',
           order: 'desc',
         },
       });
-    }, 'TorrentGalaxy');
+    }, 'GloTorrents');
 
     const $ = cheerio.load(data);
     const results = [];
 
-    $('div.tgxtablerow').each((_, row) => {
+    $('table tr').each((i, row) => {
+      if (i === 0) return;
       const $row = $(row);
+      const cells = $row.find('td');
+      if (cells.length < 6) return;
 
-      const titleEl = $row.find('a.txlight').first();
-      const title   = titleEl.text().trim();
+      const titleEl = cells.eq(1).find('a').first();
+      const title = titleEl.text().trim();
       if (!title) return;
 
       const magnetEl = $row.find('a[href^="magnet:"]').first();
-      const magnet   = magnetEl.attr('href') ?? '';
+      const magnet = magnetEl.attr('href') ?? '';
       const infoHash = extractInfoHash(magnet);
       if (!infoHash) return;
 
-      const seeders  = parseInt($row.find('span.badge-success').first().text().trim(), 10) || 0;
-      const leechers = parseInt($row.find('span.badge-danger').first().text().trim(), 10) || 0;
-
-      const sizeText = $row.find('span.badge-secondary').first().text().trim();
+      const seeders  = parseInt(cells.eq(4).text().trim(), 10) || 0;
+      const leechers = parseInt(cells.eq(5).text().trim(), 10) || 0;
+      const sizeText = cells.eq(3).text().trim();
       const size     = parseSize(sizeText);
 
       results.push({
@@ -60,15 +63,15 @@ export async function scrape(meta) {
         seeders,
         leechers,
         size,
-        provider: 'TorrentGalaxy',
-        imdbId:   meta.imdbId,
+        provider: 'GloTorrents',
+        imdbId: meta.imdbId,
         ...parseTitle(title),
       });
     });
 
     return results;
   } catch (err) {
-    logger.warn(`[TorrentGalaxy] ${err.message}`);
+    logger.warn(`[GloTorrents] ${err.message}`);
     return [];
   }
 }

--- a/scraper/providers/index.js
+++ b/scraper/providers/index.js
@@ -1,20 +1,25 @@
 /**
- * Provider aggregator — runs all enabled scrapers in parallel
+ * Provider aggregator -- runs all enabled scrapers in parallel
  * and returns a unified, deduplicated list of torrent records.
  */
 import pLimit from 'p-limit';
-import * as yts            from './yts.js';
-import * as eztv           from './eztv.js';
-import * as thepiratebay   from './thepiratebay.js';
-import * as torrentgalaxy  from './torrentgalaxy.js';
-import * as leetx          from './leetx.js';
-import * as kickasstorrents from './kickasstorrents.js';
-import * as nyaa           from './nyaa.js';
-import * as animesaturn    from './animesaturn.js';
-import * as rutor          from './rutor.js';
-import * as rutracker      from './rutracker.js';
-import * as limetorrents   from './limetorrents.js';
-import * as bitsearch      from './bitsearch.js';
+import * as yts              from './yts.js';
+import * as eztv             from './eztv.js';
+import * as thepiratebay     from './thepiratebay.js';
+import * as torrentgalaxy    from './torrentgalaxy.js';
+import * as leetx            from './leetx.js';
+import * as kickasstorrents  from './kickasstorrents.js';
+import * as nyaa             from './nyaa.js';
+import * as animesaturn      from './animesaturn.js';
+import * as rutor            from './rutor.js';
+import * as rutracker        from './rutracker.js';
+import * as limetorrents     from './limetorrents.js';
+import * as bitsearch        from './bitsearch.js';
+import * as bt4g             from './bt4g.js';
+import * as btdig            from './btdig.js';
+import * as glotorrents      from './glotorrents.js';
+import * as torlock          from './torlock.js';
+import * as torrentdownloads from './torrentdownloads.js';
 import { logger } from '../lib/logger.js';
 
 const ALL_PROVIDERS = [
@@ -30,6 +35,11 @@ const ALL_PROVIDERS = [
   rutracker,
   limetorrents,
   bitsearch,
+  bt4g,
+  btdig,
+  glotorrents,
+  torlock,
+  torrentdownloads,
 ];
 
 // Max 4 providers running simultaneously

--- a/scraper/providers/kickasstorrents.js
+++ b/scraper/providers/kickasstorrents.js
@@ -1,12 +1,13 @@
 /**
- * KickassTorrents provider — scrapes katcr.to search results.
+ * KickassTorrents provider -- scrapes search results via HTML.
  */
 import * as cheerio from 'cheerio';
 import { get } from '../lib/httpClient.js';
 import { parseTitle, buildSearchQuery } from '../lib/titleHelper.js';
+import { tryDomains, PROVIDER_DOMAINS } from '../lib/domainRotation.js';
 import { logger } from '../lib/logger.js';
 
-const BASE = 'https://katcr.to';
+const DOMAINS = PROVIDER_DOMAINS.kickasstorrents;
 
 export const id   = 'kickasstorrents';
 export const name = 'KickassTorrents';
@@ -16,11 +17,13 @@ export async function scrape(meta) {
 
   try {
     const query = buildSearchQuery(meta);
-    const url   = `${BASE}/usearch/${encodeURIComponent(query)}/`;
 
-    const { data } = await get(url, { limiterKey: 'kickasstorrents' });
+    const { data } = await tryDomains(DOMAINS, async (base) => {
+      const url = `${base}/usearch/${encodeURIComponent(query)}/`;
+      return get(url, { limiterKey: 'kickasstorrents' });
+    }, 'KAT');
+
     const $ = cheerio.load(data);
-
     const results = [];
 
     $('tr.odd, tr.even').each((_, row) => {

--- a/scraper/providers/leetx.js
+++ b/scraper/providers/leetx.js
@@ -1,12 +1,13 @@
 /**
- * 1337x provider — scrapes search and detail pages via HTML.
+ * 1337x provider -- scrapes search and detail pages via HTML.
  */
 import * as cheerio from 'cheerio';
 import { get } from '../lib/httpClient.js';
 import { parseTitle, buildSearchQuery } from '../lib/titleHelper.js';
+import { tryDomains, PROVIDER_DOMAINS } from '../lib/domainRotation.js';
 import { logger } from '../lib/logger.js';
 
-const BASE = 'https://1337x.to';
+const DOMAINS = PROVIDER_DOMAINS['1337x'];
 
 export const id   = '1337x';
 export const name = '1337x';
@@ -17,18 +18,21 @@ export async function scrape(meta) {
   try {
     const query = buildSearchQuery(meta);
     const cat   = meta.type === 'movie' ? 'Movies' : 'TV';
-    const url   = `${BASE}/category-search/${encodeURIComponent(query)}/${cat}/1/`;
 
-    const { data } = await get(url, { limiterKey: '1337x' });
+    const { data, base } = await tryDomains(DOMAINS, async (base) => {
+      const url = `${base}/category-search/${encodeURIComponent(query)}/${cat}/1/`;
+      const res = await get(url, { limiterKey: '1337x' });
+      return { data: res.data, base };
+    }, '1337x');
+
     const $ = cheerio.load(data);
 
     const detailUrls = [];
     $('table.table-list tbody tr').each((_, row) => {
       const href = $(row).find('td.name a').last().attr('href');
-      if (href) detailUrls.push(href.startsWith('http') ? href : `${BASE}${href}`);
+      if (href) detailUrls.push(href.startsWith('http') ? href : `${base}${href}`);
     });
 
-    // Fetch detail pages in batches of 5 to get magnet links
     const results = [];
     const batches = chunkArray(detailUrls.slice(0, 20), 5);
 

--- a/scraper/providers/limetorrents.js
+++ b/scraper/providers/limetorrents.js
@@ -1,12 +1,13 @@
 /**
- * LimeTorrents provider, scrapes search results and detail pages via HTML.
+ * LimeTorrents provider -- scrapes search results and detail pages via HTML.
  */
 import * as cheerio from 'cheerio';
 import { get } from '../lib/httpClient.js';
 import { parseTitle, buildSearchQuery } from '../lib/titleHelper.js';
+import { tryDomains, PROVIDER_DOMAINS } from '../lib/domainRotation.js';
 import { logger } from '../lib/logger.js';
 
-const BASE = 'https://www.limetorrents.fun';
+const DOMAINS = PROVIDER_DOMAINS.limetorrents;
 
 export const id   = 'limetorrents';
 export const name = 'LimeTorrents';
@@ -17,9 +18,13 @@ export async function scrape(meta) {
   try {
     const query = buildSearchQuery(meta);
     const type  = meta.type === 'movie' ? 'movies' : 'tv';
-    const url   = `${BASE}/search/${type}/${encodeURIComponent(query)}/seeds/1/`;
 
-    const { data } = await get(url, { limiterKey: 'limetorrents' });
+    const { data, base } = await tryDomains(DOMAINS, async (base) => {
+      const url = `${base}/search/${type}/${encodeURIComponent(query)}/seeds/1/`;
+      const res = await get(url, { limiterKey: 'limetorrents' });
+      return { data: res.data, base };
+    }, 'LimeTorrents');
+
     const $ = cheerio.load(data);
     const rows = [];
 
@@ -36,7 +41,7 @@ export async function scrape(meta) {
       rows.push({
         infoHash,
         title,
-        detailUrl: absoluteUrl(detailHref),
+        detailUrl: detailHref.startsWith('http') ? detailHref : `${base}${detailHref}`,
         seeders: parseInteger(cells.eq(3).text()),
         leechers: parseInteger(cells.eq(4).text()),
         size: parseSize(cells.eq(2).text()),
@@ -75,10 +80,6 @@ async function fetchDetail(row, meta) {
   } catch {
     return null;
   }
-}
-
-function absoluteUrl(href) {
-  return href.startsWith('http') ? href : `${BASE}${href}`;
 }
 
 function extractHashFromTorrentUrl(url = '') {

--- a/scraper/providers/thepiratebay.js
+++ b/scraper/providers/thepiratebay.js
@@ -1,11 +1,12 @@
 /**
- * The Pirate Bay provider — uses the apibay.org JSON API.
+ * The Pirate Bay provider -- uses the apibay.org JSON API.
  */
 import { get } from '../lib/httpClient.js';
 import { parseTitle, buildSearchQuery } from '../lib/titleHelper.js';
+import { tryDomains, PROVIDER_DOMAINS } from '../lib/domainRotation.js';
 import { logger } from '../lib/logger.js';
 
-const BASE = 'https://apibay.org';
+const DOMAINS = PROVIDER_DOMAINS.thepiratebay;
 
 export const id   = 'thepiratebay';
 export const name = 'ThePirateBay';
@@ -16,11 +17,13 @@ export async function scrape(meta) {
   try {
     const query = buildSearchQuery(meta);
 
-    const { data } = await get(`${BASE}/q.php`, {
-      limiterKey: 'thepiratebay',
-      responseType: 'json',
-      params: { q: query, cat: meta.type === 'movie' ? '207' : '205' },
-    });
+    const { data } = await tryDomains(DOMAINS, async (base) => {
+      return get(`${base}/q.php`, {
+        limiterKey: 'thepiratebay',
+        responseType: 'json',
+        params: { q: query, cat: meta.type === 'movie' ? '207' : '205' },
+      });
+    }, 'TPB');
 
     if (!Array.isArray(data) || data[0]?.id === '0') return [];
 

--- a/scraper/providers/torlock.js
+++ b/scraper/providers/torlock.js
@@ -1,5 +1,6 @@
 /**
- * TorrentGalaxy provider -- scrapes search results via HTML.
+ * TorLock provider -- scrapes torlock2.com search results via HTML.
+ * Verified torrents only (TorLock's USP).
  */
 import * as cheerio from 'cheerio';
 import { get } from '../lib/httpClient.js';
@@ -7,52 +8,48 @@ import { parseTitle, buildSearchQuery } from '../lib/titleHelper.js';
 import { tryDomains, PROVIDER_DOMAINS } from '../lib/domainRotation.js';
 import { logger } from '../lib/logger.js';
 
-const DOMAINS = PROVIDER_DOMAINS.torrentgalaxy;
+const DOMAINS = PROVIDER_DOMAINS.torlock;
 
-export const id   = 'torrentgalaxy';
-export const name = 'TorrentGalaxy';
+export const id   = 'torlock';
+export const name = 'TorLock';
 
 export async function scrape(meta) {
   if (!meta?.name) return [];
 
   try {
     const query = buildSearchQuery(meta);
-    const cat   = meta.type === 'movie' ? '3' : '41';
+    const cat   = meta.type === 'movie' ? 'movies' : 'television';
 
     const { data } = await tryDomains(DOMAINS, async (base) => {
-      return get(`${base}/torrents.php`, {
-        limiterKey: 'torrentgalaxy',
-        params: {
-          search: query,
-          cat,
-          lang: 0,
-          nox: 1,
-          sort: 'seeders',
-          order: 'desc',
-        },
-      });
-    }, 'TorrentGalaxy');
+      const url = `${base}/${cat}/torrents/${encodeURIComponent(query)}.html`;
+      return get(url, { limiterKey: 'torlock' });
+    }, 'TorLock');
 
     const $ = cheerio.load(data);
     const results = [];
 
-    $('div.tgxtablerow').each((_, row) => {
+    $('table tbody tr, div.table-striped article').each((_, row) => {
       const $row = $(row);
+      const cells = $row.find('td');
+      if (cells.length < 5) return;
 
-      const titleEl = $row.find('a.txlight').first();
-      const title   = titleEl.text().trim();
+      const titleEl = cells.eq(0).find('a').first();
+      const title = titleEl.text().trim();
       if (!title) return;
 
+      const detailHref = titleEl.attr('href') ?? '';
+      const torrentId = detailHref.match(/\/torrent\/(\d+)\//)?.[1];
+      if (!torrentId) return;
+
+      const seeders  = parseInt(cells.eq(3).text().trim(), 10) || 0;
+      const leechers = parseInt(cells.eq(4).text().trim(), 10) || 0;
+      const sizeText = cells.eq(2).text().trim();
+      const size     = parseSize(sizeText);
+
       const magnetEl = $row.find('a[href^="magnet:"]').first();
-      const magnet   = magnetEl.attr('href') ?? '';
+      const magnet = magnetEl.attr('href') ?? '';
       const infoHash = extractInfoHash(magnet);
       if (!infoHash) return;
-
-      const seeders  = parseInt($row.find('span.badge-success').first().text().trim(), 10) || 0;
-      const leechers = parseInt($row.find('span.badge-danger').first().text().trim(), 10) || 0;
-
-      const sizeText = $row.find('span.badge-secondary').first().text().trim();
-      const size     = parseSize(sizeText);
 
       results.push({
         infoHash,
@@ -60,15 +57,15 @@ export async function scrape(meta) {
         seeders,
         leechers,
         size,
-        provider: 'TorrentGalaxy',
-        imdbId:   meta.imdbId,
+        provider: 'TorLock',
+        imdbId: meta.imdbId,
         ...parseTitle(title),
       });
     });
 
     return results;
   } catch (err) {
-    logger.warn(`[TorrentGalaxy] ${err.message}`);
+    logger.warn(`[TorLock] ${err.message}`);
     return [];
   }
 }

--- a/scraper/providers/torrentdownloads.js
+++ b/scraper/providers/torrentdownloads.js
@@ -1,5 +1,5 @@
 /**
- * TorrentGalaxy provider -- scrapes search results via HTML.
+ * TorrentDownloads provider -- scrapes torrentdownload.info search results via HTML.
  */
 import * as cheerio from 'cheerio';
 import { get } from '../lib/httpClient.js';
@@ -7,68 +7,68 @@ import { parseTitle, buildSearchQuery } from '../lib/titleHelper.js';
 import { tryDomains, PROVIDER_DOMAINS } from '../lib/domainRotation.js';
 import { logger } from '../lib/logger.js';
 
-const DOMAINS = PROVIDER_DOMAINS.torrentgalaxy;
+const DOMAINS = PROVIDER_DOMAINS.torrentdownloads;
 
-export const id   = 'torrentgalaxy';
-export const name = 'TorrentGalaxy';
+export const id   = 'torrentdownloads';
+export const name = 'TorrentDownloads';
 
 export async function scrape(meta) {
   if (!meta?.name) return [];
 
   try {
     const query = buildSearchQuery(meta);
-    const cat   = meta.type === 'movie' ? '3' : '41';
+    const cat   = meta.type === 'movie' ? '4' : '8';
 
     const { data } = await tryDomains(DOMAINS, async (base) => {
-      return get(`${base}/torrents.php`, {
-        limiterKey: 'torrentgalaxy',
-        params: {
-          search: query,
-          cat,
-          lang: 0,
-          nox: 1,
-          sort: 'seeders',
-          order: 'desc',
-        },
+      return get(`${base}/search/`, {
+        limiterKey: 'torrentdownloads',
+        params: { search: query, cat },
       });
-    }, 'TorrentGalaxy');
+    }, 'TorrentDownloads');
 
     const $ = cheerio.load(data);
     const results = [];
 
-    $('div.tgxtablerow').each((_, row) => {
+    $('table.table2 tr, div.grey_bar3').each((i, row) => {
+      if (i === 0) return;
       const $row = $(row);
+      const cells = $row.find('td');
+      if (cells.length < 4) return;
 
-      const titleEl = $row.find('a.txlight').first();
-      const title   = titleEl.text().trim();
+      const titleEl = cells.eq(0).find('a').first();
+      const title = titleEl.text().trim();
       if (!title) return;
 
       const magnetEl = $row.find('a[href^="magnet:"]').first();
-      const magnet   = magnetEl.attr('href') ?? '';
+      const magnet = magnetEl.attr('href') ?? '';
       const infoHash = extractInfoHash(magnet);
-      if (!infoHash) return;
 
-      const seeders  = parseInt($row.find('span.badge-success').first().text().trim(), 10) || 0;
-      const leechers = parseInt($row.find('span.badge-danger').first().text().trim(), 10) || 0;
+      const detailHref = titleEl.attr('href') ?? '';
+      const hashFromUrl = detailHref.match(/([a-fA-F0-9]{40})/)?.[1]?.toLowerCase();
 
-      const sizeText = $row.find('span.badge-secondary').first().text().trim();
+      const hash = infoHash ?? hashFromUrl;
+      if (!hash) return;
+
+      const seeders  = parseInt(cells.eq(2).text().trim(), 10) || 0;
+      const leechers = parseInt(cells.eq(3).text().trim(), 10) || 0;
+      const sizeText = cells.eq(1).text().trim();
       const size     = parseSize(sizeText);
 
       results.push({
-        infoHash,
+        infoHash: hash,
         title,
         seeders,
         leechers,
         size,
-        provider: 'TorrentGalaxy',
-        imdbId:   meta.imdbId,
+        provider: 'TorrentDownloads',
+        imdbId: meta.imdbId,
         ...parseTitle(title),
       });
     });
 
     return results;
   } catch (err) {
-    logger.warn(`[TorrentGalaxy] ${err.message}`);
+    logger.warn(`[TorrentDownloads] ${err.message}`);
     return [];
   }
 }

--- a/scraper/providers/yts.js
+++ b/scraper/providers/yts.js
@@ -1,12 +1,13 @@
 /**
- * YTS provider — uses the official YTS JSON API.
+ * YTS provider -- uses the official YTS JSON API.
  * Supports movies only (no series).
  */
 import { get } from '../lib/httpClient.js';
 import { parseTitle } from '../lib/titleHelper.js';
+import { tryDomains, PROVIDER_DOMAINS } from '../lib/domainRotation.js';
 import { logger } from '../lib/logger.js';
 
-const BASE = 'https://yts.mx/api/v2';
+const DOMAINS = PROVIDER_DOMAINS.yts;
 
 export const id   = 'yts';
 export const name = 'YTS';
@@ -15,15 +16,17 @@ export async function scrape(meta) {
   if (meta.type !== 'movie') return [];
 
   try {
-    const { data } = await get(`${BASE}/list_movies.json`, {
-      limiterKey: 'yts',
-      responseType: 'json',
-      params: {
-        query_term: meta.imdbId,
-        limit: 50,
-        sort_by: 'seeds',
-      },
-    });
+    const { data } = await tryDomains(DOMAINS, async (base) => {
+      return get(`${base}/api/v2/list_movies.json`, {
+        limiterKey: 'yts',
+        responseType: 'json',
+        params: {
+          query_term: meta.imdbId,
+          limit: 50,
+          sort_by: 'seeds',
+        },
+      });
+    }, 'YTS');
 
     const movies = data?.data?.movies ?? [];
     return movies.flatMap(movie =>


### PR DESCRIPTION
## Summary
- Add domain rotation utility (`scraper/lib/domainRotation.js`) that automatically tries multiple domains per provider, including unblockit.download proxy mirrors as fallback when primary domains are ISP-blocked or down. Failed domains get a 5-minute cooldown before retrying.
- Add 5 new torrent providers: BT4G, BTDig, GloTorrents, TorLock, TorrentDownloads
- Update 7 existing providers (1337x, EZTV, LimeTorrents, KickassTorrents, TorrentGalaxy, YTS, ThePirateBay) with domain failover and unblockit mirrors

Total providers: 12 -> 17

## Test plan
- [ ] Deploy to Pi and verify scraper starts without errors
- [ ] Search for a movie and confirm results come from new providers
- [ ] Block a primary domain (e.g. 1337x.to) and verify failover to unblockit mirror works
- [ ] Check logs for domain rotation debug messages

Generated with [Claude Code](https://claude.com/claude-code)