### PR TITLE
Add daily prewarm cron and automate debrid behavior

### DIFF
--- a/addon/addon.js
+++ b/addon/addon.js
@@ -142,7 +142,7 @@ function logStreamSummary({ type, id, config, records, filtered, baseStreams, fi
     `Stream ${type}/${id}: providers=${(config.providers || []).join(',') || 'default'} ` +
     `qualities=${(config.qualities || []).join(',') || 'all'} ` +
     `languages=${(config.languages || []).join(',') || 'all'} ` +
-    `limit=${config.limit ?? 10} debrid=${debrid} p2pFallback=${config.p2pFallback ? '1' : '0'} ` +
+    `limit=${config.limit ?? 10} debrid=${debrid} ` +
     `records=${records.length} filtered=${filtered.length} base=${baseStreams.length} ` +
     `final=${finalStreams.length} direct=${direct} p2p=${p2p}`
   );

--- a/addon/lib/configuration.js
+++ b/addon/lib/configuration.js
@@ -99,9 +99,6 @@ export function parseConfiguration(configString) {
       case 'prewarmlimit':
         config.prewarmLimit = clampPrewarmLimit(parseInt(value, 10), config.prewarmLimit);
         break;
-      case 'p2pfallback':
-        config.p2pFallback = parseBoolean(value, config.p2pFallback);
-        break;
       case 'excludesizes':
         config.excludeSizes = value.toUpperCase().split(',').filter(Boolean);
         break;
@@ -166,7 +163,6 @@ export function getDefaultConfiguration() {
     subtitleLanguages:  ['en'],       // subtitle preference defaults to English
     prewarmDebrid:      true,         // warm a few top uncached results in debrid
     prewarmLimit:       3,
-    p2pFallback:        false,        // debrid configs return direct streams unless opted in
     excludeSizes:       [],
     maxSize:            null,
     // Debrid keys (all null by default)

--- a/addon/lib/landingTemplate.js
+++ b/addon/lib/landingTemplate.js
@@ -47,7 +47,6 @@ export function landingTemplate(manifest, initialConfig = {}) {
     subtitleLanguages: initialConfig.subtitleLanguages ?? ['en'],
     prewarmDebrid: initialConfig.prewarmDebrid ?? true,
     prewarmLimit: initialConfig.prewarmLimit ?? 3,
-    p2pFallback: initialConfig.p2pFallback === true,
     realDebridApiKey: initialConfig.realDebridApiKey ?? '',
     premiumizeApiKey: initialConfig.premiumizeApiKey ?? '',
     allDebridApiKey: initialConfig.allDebridApiKey ?? '',
@@ -392,7 +391,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
 
       <section class="panel section">
         <h2>Debrid</h2>
-        <p>Paste only the services you actually use. Cached matches are emitted as direct debrid streams first. P2P fallback is optional.</p>
+        <p>Paste only the services you actually use. Cached matches are emitted as direct debrid streams. Without a debrid key, Magnetio returns raw torrent streams instead.</p>
         <div class="grid">
           <label>
             Debrid prewarm
@@ -408,13 +407,6 @@ export function landingTemplate(manifest, initialConfig = {}) {
               <option value="2">2</option>
               <option value="3">3</option>
               <option value="5">5</option>
-            </select>
-          </label>
-          <label>
-            P2P fallback
-            <select id="p2pFallback">
-              <option value="0">Direct debrid only</option>
-              <option value="1">Allow torrent fallback</option>
             </select>
           </label>
         </div>
@@ -472,8 +464,6 @@ export function landingTemplate(manifest, initialConfig = {}) {
       document.getElementById('limit').value = String(initialConfig.limit || 10);
       document.getElementById('prewarm').value = initialConfig.prewarmDebrid === false ? '0' : '1';
       document.getElementById('prewarmLimit').value = String(initialConfig.prewarmLimit || 3);
-      document.getElementById('p2pFallback').value = initialConfig.p2pFallback ? '1' : '0';
-
       setMultiSelect('qualities', initialConfig.qualities || []);
       setMultiSelect('languages', initialConfig.languages || []);
       setMultiSelect('subtitleLanguages', initialConfig.subtitleLanguages || ['en']);
@@ -495,7 +485,6 @@ export function landingTemplate(manifest, initialConfig = {}) {
       const limit = document.getElementById('limit').value;
       const prewarm = document.getElementById('prewarm').value;
       const prewarmLimit = document.getElementById('prewarmLimit').value;
-      const p2pFallback = document.getElementById('p2pFallback').value;
       const qualities = selectedValues('qualities');
       const languages = selectedValues('languages');
       const subtitleLanguages = selectedValues('subtitleLanguages');
@@ -504,7 +493,6 @@ export function landingTemplate(manifest, initialConfig = {}) {
       parts.push('limit=' + limit);
       parts.push('prewarm=' + prewarm);
       parts.push('prewarmLimit=' + prewarmLimit);
-      parts.push('p2pFallback=' + p2pFallback);
       if (qualities.length) parts.push('qualities=' + qualities.join(','));
       if (languages.length) parts.push('languages=' + languages.join(','));
       if (subtitleLanguages.length) parts.push('subtitleLanguages=' + subtitleLanguages.join(','));

--- a/addon/moch/moch.js
+++ b/addon/moch/moch.js
@@ -37,7 +37,7 @@ const resolveLimit = pLimit(4);
  * For each enabled service:
  *   1. Check which infoHashes are instantly available (cached).
  *   2. Re-emit cached streams as direct-download streams.
- *   3. Return direct streams first, with optional P2P fallback.
+ *   3. Return direct streams only. Users without debrid keys get raw P2P torrents instead.
  *
  * @param {StreamObject[]} streams         Raw stream objects from repository
  * @param {object}         config          Addon configuration
@@ -95,16 +95,11 @@ export async function applyMochs(streams, config, requestContext) {
   );
 
   if (directStreams.length) {
-    return config?.p2pFallback ? [...directStreams, ...streams] : directStreams;
+    return directStreams;
   }
 
-  if (config?.p2pFallback) {
-    logger.warn(`No debrid streams resolved, falling back to P2P (${streams.length} raw streams)`);
-    return streams;
-  }
-
-  logger.warn('No debrid streams resolved and P2P fallback is disabled');
-  return [];
+  logger.warn(`No debrid streams resolved, returning raw P2P (${streams.length} streams)`);
+  return streams;
 }
 
 async function withTimeout(promise, timeoutMs, message) {

--- a/addon/test/sdk-upgrade.test.js
+++ b/addon/test/sdk-upgrade.test.js
@@ -27,17 +27,10 @@ test('public provider aliases map to internal providers', () => {
 });
 
 test('configuration parser supports debrid prewarm controls', () => {
-  const config = parseConfiguration('prewarm=0|prewarmLimit=5|p2pFallback=1');
+  const config = parseConfiguration('prewarm=0|prewarmLimit=5');
 
   assert.equal(config.prewarmDebrid, false);
   assert.equal(config.prewarmLimit, 5);
-  assert.equal(config.p2pFallback, true);
-});
-
-test('debrid configs default to direct-only stream output', () => {
-  const config = parseConfiguration('rd=abcdefghijklmnop');
-
-  assert.equal(config.p2pFallback, false);
 });
 
 test('final stream limit caps visible streams after debrid enrichment', () => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,11 @@ services:
       - REDIS_URI=redis://redis:6379
       - CACHE_TTL_STREAMS=${CACHE_TTL_STREAMS:-3600}
       - LOG_LEVEL=${LOG_LEVEL:-info}
+      - PREWARM_ENABLED=${PREWARM_ENABLED:-true}
+      - PREWARM_SCHEDULE=${PREWARM_SCHEDULE:-0 4 * * *}
+      - PREWARM_MOVIE_LIMIT=${PREWARM_MOVIE_LIMIT:-50}
+      - PREWARM_SERIES_LIMIT=${PREWARM_SERIES_LIMIT:-20}
+      - PREWARM_CACHE_TTL=${PREWARM_CACHE_TTL:-14400}
     depends_on:
       redis:
         condition: service_healthy

--- a/scraper/index.js
+++ b/scraper/index.js
@@ -3,6 +3,8 @@ import express from 'express';
 import { scrapeAll, listProviders } from './providers/index.js';
 import { getMetadata } from './lib/cinemeta.js';
 import { cacheWrap } from './lib/cache.js';
+import { startCronJobs } from './lib/cron.js';
+import { runPrewarm, getPrewarmStatus } from './lib/prewarm.js';
 import { logger } from './lib/logger.js';
 
 const app  = express();
@@ -72,6 +74,19 @@ app.get('/streams/:type/:id', async (req, res) => {
   }
 });
 
+// ─── Prewarm ─────────────────────────────────────────────────────────────────
+
+app.post('/prewarm', (_req, res) => {
+  const { running } = getPrewarmStatus();
+  if (running) return res.status(409).json({ error: 'Prewarm already running' });
+  runPrewarm().catch(err => logger.error(`[Prewarm] ${err.message}`));
+  res.status(202).json({ message: 'Prewarm started' });
+});
+
+app.get('/prewarm/status', (_req, res) => {
+  res.json(getPrewarmStatus());
+});
+
 // ─── 404 ──────────────────────────────────────────────────────────────────────
 
 app.use((_req, res) => res.status(404).json({ error: 'Not found' }));
@@ -80,6 +95,7 @@ app.use((_req, res) => res.status(404).json({ error: 'Not found' }));
 
 app.listen(PORT, () => {
   logger.info(`Magnetio scraper running on port ${PORT}`);
+  startCronJobs();
 });
 
 export default app;

--- a/scraper/lib/cache.js
+++ b/scraper/lib/cache.js
@@ -18,6 +18,12 @@ function getStore() {
   return _store;
 }
 
+export async function cacheHas(key) {
+  const store = getStore();
+  const hit = await store.get(key);
+  return hit !== undefined;
+}
+
 export async function cacheWrap(key, loader, ttlSeconds = 3600) {
   const store = getStore();
   const hit = await store.get(key);

--- a/scraper/lib/catalog.js
+++ b/scraper/lib/catalog.js
@@ -14,6 +14,7 @@ export async function fetchPopular(type, limit = 50) {
     const metas = data?.metas ?? [];
 
     return metas.slice(0, limit).map(m => ({
+      // Series prewarm targets S01E01 only; other episodes get scraped on demand
       id: type === 'series' ? `${m.imdb_id}:1:1` : m.imdb_id,
       name: m.name,
       type,

--- a/scraper/lib/catalog.js
+++ b/scraper/lib/catalog.js
@@ -1,0 +1,25 @@
+import { get } from './httpClient.js';
+import { logger } from './logger.js';
+
+const CINEMETA_BASE = 'https://v3-cinemeta.strem.io';
+
+export async function fetchPopular(type, limit = 50) {
+  try {
+    const { data } = await get(`${CINEMETA_BASE}/catalog/${type}/top.json`, {
+      limiterKey: 'cinemeta',
+      responseType: 'json',
+      timeout: 15000,
+    });
+
+    const metas = data?.metas ?? [];
+
+    return metas.slice(0, limit).map(m => ({
+      id: type === 'series' ? `${m.imdb_id}:1:1` : m.imdb_id,
+      name: m.name,
+      type,
+    }));
+  } catch (err) {
+    logger.error(`[Catalog] Failed to fetch popular ${type}: ${err.message}`);
+    return [];
+  }
+}

--- a/scraper/lib/cron.js
+++ b/scraper/lib/cron.js
@@ -1,0 +1,28 @@
+import cron from 'node-cron';
+import { runPrewarm } from './prewarm.js';
+import { logger } from './logger.js';
+
+const ENABLED  = (process.env.PREWARM_ENABLED ?? 'true') === 'true';
+const SCHEDULE = process.env.PREWARM_SCHEDULE ?? '0 4 * * *';
+
+export function startCronJobs() {
+  if (!ENABLED) {
+    logger.info('[Cron] Prewarm disabled (PREWARM_ENABLED=false)');
+    return;
+  }
+
+  if (!cron.validate(SCHEDULE)) {
+    logger.error(`[Cron] Invalid schedule: "${SCHEDULE}"`);
+    return;
+  }
+
+  cron.schedule(SCHEDULE, async () => {
+    try {
+      await runPrewarm();
+    } catch (err) {
+      logger.error(`[Cron] Prewarm failed: ${err.message}`);
+    }
+  });
+
+  logger.info(`[Cron] Prewarm scheduled: "${SCHEDULE}"`);
+}

--- a/scraper/lib/prewarm.js
+++ b/scraper/lib/prewarm.js
@@ -80,6 +80,11 @@ async function prewarmTitle(item, stats) {
   logger.debug(`[Prewarm] Scraping ${label}`);
 
   const streams = await scrapeAll(type, meta);
+  if (!streams.length) {
+    stats.failed++;
+    logger.debug(`[Prewarm] No streams found for ${id}, skipping cache write`);
+    return;
+  }
   await cacheWrap(cacheKey, () => streams, CACHE_TTL);
   stats.scraped++;
 }

--- a/scraper/lib/prewarm.js
+++ b/scraper/lib/prewarm.js
@@ -1,0 +1,85 @@
+import pLimit from 'p-limit';
+import { fetchPopular } from './catalog.js';
+import { getMetadata } from './cinemeta.js';
+import { scrapeAll } from '../providers/index.js';
+import { cacheWrap, cacheHas } from './cache.js';
+import { logger } from './logger.js';
+
+const MOVIE_LIMIT  = parseInt(process.env.PREWARM_MOVIE_LIMIT ?? '50', 10);
+const SERIES_LIMIT = parseInt(process.env.PREWARM_SERIES_LIMIT ?? '20', 10);
+const CACHE_TTL    = parseInt(process.env.PREWARM_CACHE_TTL ?? '14400', 10);
+
+let lastRun = null;
+let running = false;
+
+export function getPrewarmStatus() {
+  return { running, lastRun };
+}
+
+export async function runPrewarm() {
+  if (running) {
+    logger.warn('[Prewarm] Already running, skipping');
+    return null;
+  }
+
+  running = true;
+  const start = Date.now();
+  const stats = { processed: 0, cached: 0, scraped: 0, failed: 0 };
+
+  try {
+    logger.info('[Prewarm] Starting cache prewarm...');
+
+    const [movies, series] = await Promise.all([
+      fetchPopular('movie', MOVIE_LIMIT),
+      fetchPopular('series', SERIES_LIMIT),
+    ]);
+
+    const titles = [...movies, ...series];
+    logger.info(`[Prewarm] ${movies.length} movies + ${series.length} series = ${titles.length} titles`);
+
+    const concurrency = pLimit(2);
+
+    await Promise.allSettled(
+      titles.map(item => concurrency(async () => {
+        stats.processed++;
+        try {
+          await prewarmTitle(item, stats);
+        } catch (err) {
+          stats.failed++;
+          logger.warn(`[Prewarm] Failed ${item.id}: ${err.message}`);
+        }
+      }))
+    );
+
+    const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+    lastRun = { ...stats, elapsed: `${elapsed}s`, timestamp: new Date().toISOString() };
+    logger.info(`[Prewarm] Done in ${elapsed}s: ${JSON.stringify(stats)}`);
+    return lastRun;
+  } finally {
+    running = false;
+  }
+}
+
+async function prewarmTitle(item, stats) {
+  const { type, id } = item;
+  const cacheKey = `streams:${type}:${id}:all`;
+
+  const alreadyCached = await cacheHas(cacheKey);
+  if (alreadyCached) {
+    stats.cached++;
+    return;
+  }
+
+  const meta = await getMetadata(type, id);
+  if (!meta) {
+    stats.failed++;
+    return;
+  }
+
+  const label = meta.year ? `"${meta.name}" (${meta.year})` : `"${meta.name}"`;
+  logger.debug(`[Prewarm] Scraping ${label}`);
+
+  const streams = await scrapeAll(type, meta);
+  await cacheWrap(cacheKey, () => streams, CACHE_TTL);
+  stats.scraped++;
+}

--- a/scraper/package-lock.json
+++ b/scraper/package-lock.json
@@ -17,6 +17,7 @@
         "express": "^4.18.2",
         "iconv-lite": "^0.6.3",
         "keyv": "^4.5.4",
+        "node-cron": "^3.0.3",
         "p-limit": "^5.0.0",
         "winston": "^3.11.0"
       },
@@ -1327,6 +1328,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/nodemon": {
       "version": "3.1.14",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
@@ -1984,6 +1997,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/scraper/package.json
+++ b/scraper/package.json
@@ -20,7 +20,8 @@
     "dotenv": "^16.3.1",
     "iconv-lite": "^0.6.3",
     "p-limit": "^5.0.0",
-    "bottleneck": "^2.19.5"
+    "bottleneck": "^2.19.5",
+    "node-cron": "^3.0.3"
   },
   "devDependencies": {
     "nodemon": "^3.0.2"


### PR DESCRIPTION
## Summary
- Add a daily cron job (default 4 AM) that fetches popular movies/series from Cinemeta and pre-populates the scraper Redis cache with a 4-hour TTL, eliminating cold-scrape delays for popular content
- Add `POST /prewarm` endpoint for manual trigger and `GET /prewarm/status` for observability
- Remove the P2P fallback config dropdown from the UI; debrid behavior is now automatic (direct streams when API keys are present, raw torrents otherwise)
- Configurable via `PREWARM_ENABLED`, `PREWARM_SCHEDULE`, `PREWARM_MOVIE_LIMIT`, `PREWARM_SERIES_LIMIT`, `PREWARM_CACHE_TTL` environment variables

## Test plan
- [x] All 16 addon tests pass
- [ ] Deploy and trigger manual prewarm: `curl -X POST http://localhost:8080/prewarm`
- [ ] Verify Redis has cached entries: `redis-cli keys "scraper:streams:*"`
- [ ] Check prewarm status: `curl http://localhost:8080/prewarm/status`
- [ ] Confirm addon with debrid keys returns direct streams only
- [ ] Confirm addon without debrid keys returns raw torrent streams