### PR TITLE
Add analytics and update CI to Node 22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,14 +22,14 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: |
             addon/package-lock.json
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/addon/lib/analytics.js
+++ b/addon/lib/analytics.js
@@ -1,0 +1,105 @@
+import { createClient } from 'redis';
+import { logger } from './logger.js';
+
+let client = null;
+let enabled = false;
+
+const PREFIX = 'magnetio:stats';
+
+async function getClient() {
+  if (client) return client;
+  if (!process.env.REDIS_URI) return null;
+
+  try {
+    client = createClient({ url: process.env.REDIS_URI });
+    client.on('error', err => logger.debug(`Analytics redis error: ${err.message}`));
+    await client.connect();
+    enabled = true;
+    return client;
+  } catch (err) {
+    logger.debug(`Analytics disabled: ${err.message}`);
+    return null;
+  }
+}
+
+function todayKey() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export async function trackRequest(type, configHash) {
+  const redis = await getClient();
+  if (!redis) return;
+
+  const day = todayKey();
+  try {
+    await Promise.all([
+      redis.incr(`${PREFIX}:requests:${day}`),
+      redis.incr(`${PREFIX}:requests:total`),
+      redis.incr(`${PREFIX}:${type}:${day}`),
+      redis.pfAdd(`${PREFIX}:users:${day}`, configHash),
+      redis.pfAdd(`${PREFIX}:users:total`, configHash),
+    ]);
+  } catch {
+    // analytics are best-effort, never block requests
+  }
+}
+
+export async function getStats() {
+  const redis = await getClient();
+  if (!redis) return { enabled: false };
+
+  const day = todayKey();
+  try {
+    const [
+      totalRequests,
+      todayRequests,
+      todayStreams,
+      todayCatalogs,
+      todaySubtitles,
+      todayPages,
+      totalUsers,
+      todayUsers,
+    ] = await Promise.all([
+      redis.get(`${PREFIX}:requests:total`),
+      redis.get(`${PREFIX}:requests:${day}`),
+      redis.get(`${PREFIX}:stream:${day}`),
+      redis.get(`${PREFIX}:catalog:${day}`),
+      redis.get(`${PREFIX}:subtitle:${day}`),
+      redis.get(`${PREFIX}:page:${day}`),
+      redis.pfCount(`${PREFIX}:users:total`),
+      redis.pfCount(`${PREFIX}:users:${day}`),
+    ]);
+
+    const last7 = [];
+    for (let i = 0; i < 7; i++) {
+      const d = new Date();
+      d.setDate(d.getDate() - i);
+      const key = d.toISOString().slice(0, 10);
+      const [reqs, users] = await Promise.all([
+        redis.get(`${PREFIX}:requests:${key}`),
+        redis.pfCount(`${PREFIX}:users:${key}`),
+      ]);
+      last7.push({ date: key, requests: parseInt(reqs || '0', 10), users });
+    }
+
+    return {
+      enabled: true,
+      total: {
+        requests: parseInt(totalRequests || '0', 10),
+        uniqueUsers: totalUsers,
+      },
+      today: {
+        date: day,
+        requests: parseInt(todayRequests || '0', 10),
+        uniqueUsers: todayUsers,
+        streams: parseInt(todayStreams || '0', 10),
+        catalogs: parseInt(todayCatalogs || '0', 10),
+        subtitles: parseInt(todaySubtitles || '0', 10),
+        pages: parseInt(todayPages || '0', 10),
+      },
+      last7days: last7,
+    };
+  } catch (err) {
+    return { enabled: true, error: err.message };
+  }
+}

--- a/addon/serverless.js
+++ b/addon/serverless.js
@@ -8,6 +8,7 @@ import { getAddonInterface } from './addon.js';
 import { landingTemplate } from './lib/landingTemplate.js';
 import { logger } from './lib/logger.js';
 import { handleSubtitleProxyRequest } from './lib/subtitleProxy.js';
+import { trackRequest, getStats } from './lib/analytics.js';
 
 const router = express.Router();
 const ROUTER_CACHE_TTL_MS = 1000 * 60 * 5;
@@ -43,6 +44,11 @@ router.get('/health', (_req, res) => {
   res.json({ status: 'ok', service: 'Magnetio', version: '1.1.5' });
 });
 
+router.get('/stats', async (_req, res) => {
+  const stats = await getStats();
+  res.json(stats);
+});
+
 router.get('/:configuration', (req, res) => {
   try {
     const config = parseConfiguration(req.params.configuration);
@@ -67,6 +73,11 @@ router.get('/:configuration/configure', (req, res) => {
 
 router.use('/:configuration', async (req, res, next) => {
   try {
+    const configHash = hashConfiguration(req.params.configuration);
+    const pathAfterConfig = req.path.replace(/^\/[^/]+/, '');
+    const type = pathAfterConfig.match(/^\/(stream|catalog|subtitle|meta)\b/)?.[1] || 'page';
+    trackRequest(type, configHash).catch(() => {});
+
     const addonRouter = await getConfiguredAddonRouter(
       req.params.configuration,
       getPublicBaseUrl(req),


### PR DESCRIPTION
## Summary
- Add Redis-based analytics tracking with HyperLogLog for privacy-preserving unique user counting
- New `/stats` endpoint to view request counts and unique users (today, total, last 7 days)
- Update deploy workflow to actions/checkout@v6, actions/setup-node@v6, Node.js 22
- Best-effort tracking that never blocks addon requests

## Test plan
- [x] All 16 addon tests pass
- [ ] Verify /stats endpoint returns data when Redis is available
- [ ] Verify addon works normally when Redis is unavailable (analytics silently disabled)