### PR TITLE
Restrict deploy to repo owner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,9 @@ jobs:
   deploy:
     name: deploy
     needs: validate
-    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+    if: >-
+      github.actor == 'peterdsp' &&
+      (github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main')
     runs-on: [self-hosted, raspberry-pi, production]
     environment: production
     timeout-minutes: 20


### PR DESCRIPTION
## Summary
- Only `peterdsp` can trigger production deploys (push to main or workflow_dispatch)
- Other actors are silently skipped, no environment approval needed
- Avoids the self-review deadlock while keeping deploys locked to the owner

## Test plan
- [x] Verify deploy job condition syntax
- [ ] Push to main as peterdsp and confirm deploy runs
- [ ] Confirm non-peterdsp actors would skip the deploy job