### PR TITLE
Fix scraper reliability: provider sync, cache, metadata fallback

### DIFF
--- a/addon/lib/cache.js
+++ b/addon/lib/cache.js
@@ -34,7 +34,10 @@ export async function cacheWrap(key, loader, ttl = 3600) {
   if (cached !== undefined) return cached;
 
   const value = await loader();
-  await store.set(key, value, ttl * 1000); // Keyv uses milliseconds
+  const isEmpty = Array.isArray(value) && value.length === 0;
+  if (!isEmpty) {
+    await store.set(key, value, ttl * 1000); // Keyv uses milliseconds
+  }
   return value;
 }
 

--- a/addon/lib/configuration.js
+++ b/addon/lib/configuration.js
@@ -3,7 +3,6 @@ import { TorrentProvider, SortType, SizeLimit } from './types.js';
 const PublicProviderAliases = {
   s1: TorrentProvider.YTS,
   s2: TorrentProvider.EZTV,
-  s3: TorrentProvider.RARBG,
   s4: TorrentProvider.TORRENTGALAXY,
   s5: TorrentProvider.THEPIRATEBAY,
   s6: TorrentProvider.KICKASSTORRENTS,
@@ -14,6 +13,12 @@ const PublicProviderAliases = {
   s11: TorrentProvider.RUTRACKER,
   s12: TorrentProvider.LIMETORRENTS,
   s13: TorrentProvider.BITSEARCH,
+  s14: TorrentProvider.BT4G,
+  s15: TorrentProvider.BTDIG,
+  s16: TorrentProvider.GLOTORRENTS,
+  s17: TorrentProvider.TORLOCK,
+  s18: TorrentProvider.TORRENTDOWNLOADS,
+  rarbg: TorrentProvider.TORRENTGALAXY,
 };
 
 // Pre-built Configurations

--- a/addon/lib/types.js
+++ b/addon/lib/types.js
@@ -9,7 +9,6 @@ export const ContentType = {
 export const TorrentProvider = {
   YTS: 'yts',
   EZTV: 'eztv',
-  RARBG: 'rarbg',
   TORRENTGALAXY: 'torrentgalaxy',
   THEPIRATEBAY: 'thepiratebay',
   KICKASSTORRENTS: 'kickasstorrents',
@@ -20,6 +19,11 @@ export const TorrentProvider = {
   RUTRACKER: 'rutracker',
   LIMETORRENTS: 'limetorrents',
   BITSEARCH: 'bitsearch',
+  BT4G: 'bt4g',
+  BTDIG: 'btdig',
+  GLOTORRENTS: 'glotorrents',
+  TORLOCK: 'torlock',
+  TORRENTDOWNLOADS: 'torrentdownloads',
 };
 
 // Sort options exposed in configuration

--- a/scraper/index.js
+++ b/scraper/index.js
@@ -52,7 +52,7 @@ app.get('/streams/:type/:id', async (req, res) => {
   const cacheKey = `streams:${type}:${id}:${providerIds?.join(',') ?? 'all'}`;
 
   try {
-    const streams = await cacheWrap(cacheKey, async () => {
+    const { value: streams, cached } = await cacheWrap(cacheKey, async () => {
       // 1. Resolve metadata (title, year, season, episode)
       const meta = await getMetadata(type === 'anime' ? 'series' : type, id);
       if (!meta) {
@@ -67,7 +67,7 @@ app.get('/streams/:type/:id', async (req, res) => {
       return scrapeAll(type, meta, providerIds);
     }, TTL_STREAMS);
 
-    res.json({ streams, cached: true });
+    res.json({ streams, cached });
   } catch (err) {
     logger.error(`Streams error [${id}]: ${err.message}`);
     res.status(500).json({ error: err.message, streams: [] });

--- a/scraper/lib/cache.js
+++ b/scraper/lib/cache.js
@@ -27,8 +27,11 @@ export async function cacheHas(key) {
 export async function cacheWrap(key, loader, ttlSeconds = 3600) {
   const store = getStore();
   const hit = await store.get(key);
-  if (hit !== undefined) return hit;
+  if (hit !== undefined) return { value: hit, cached: true };
   const value = await loader();
-  await store.set(key, value, ttlSeconds * 1000);
-  return value;
+  const isEmpty = Array.isArray(value) && value.length === 0;
+  if (!isEmpty) {
+    await store.set(key, value, ttlSeconds * 1000);
+  }
+  return { value, cached: false };
 }

--- a/scraper/lib/cinemeta.js
+++ b/scraper/lib/cinemeta.js
@@ -5,10 +5,21 @@ import { logger } from './logger.js';
 const CINEMETA_BASE = 'https://v3-cinemeta.strem.io/meta';
 const TIMEOUT = 8000;
 
-/**
- * Try fetching metadata from Cinemeta for a given type and IMDB ID.
- * Returns the meta object or null.
- */
+async function fetchImdbTitle(imdbId) {
+  try {
+    const { data } = await axios.get(
+      `https://sg.media-imdb.com/suggests/t/${imdbId}.json`,
+      { timeout: TIMEOUT, responseType: 'text' }
+    );
+    const jsonStr = data.replace(/^imdb\$[^(]*\(/, '').replace(/\);?\s*$/, '');
+    const parsed = JSON.parse(jsonStr);
+    const match = parsed?.d?.find(item => item.id === imdbId);
+    return match?.l || null;
+  } catch {
+    return null;
+  }
+}
+
 async function fetchCinemeta(type, imdbId) {
   try {
     const { data } = await axios.get(
@@ -47,7 +58,7 @@ export async function getMetadata(type, id) {
 
   const cacheKey = `cinemeta:${type}:${imdbId}`;
 
-  const meta = await cacheWrap(cacheKey, async () => {
+  const { value: meta } = await cacheWrap(cacheKey, async () => {
     // Primary lookup
     const primary = await fetchCinemeta(type, imdbId);
     if (primary) return primary;
@@ -61,10 +72,16 @@ export async function getMetadata(type, id) {
       return { ...alt, type };
     }
 
-    // Last resort: minimal stub so providers that search by IMDB ID can still work
-    logger.warn(`Cinemeta has no data for ${imdbId}, using IMDB ID stub`);
-    return { name: imdbId, year: null, imdbId, type };
-  }, 3600); // 1h cache - short enough to retry failures, fine for successes
+    // Last resort: try fetching the title from IMDB directly
+    const imdbTitle = await fetchImdbTitle(imdbId);
+    if (imdbTitle) {
+      logger.info(`IMDB fallback hit: ${imdbId} -> "${imdbTitle}"`);
+      return { name: imdbTitle, year: null, imdbId, type };
+    }
+
+    logger.warn(`No metadata found for ${imdbId} from any source`);
+    return null;
+  }, 3600);
 
   if (!meta) return null;
   return { ...meta, season, episode };


### PR DESCRIPTION
## Summary
- Sync addon provider list with scraper (add bt4g, btdig, glotorrents, torlock, torrentdownloads; drop dead rarbg with backwards-compat alias)
- Stop caching empty results so users can retry on transient failures
- Return real cache hit/miss status instead of hardcoded true
- Add IMDB suggestions API as last-resort metadata fallback when cinemeta returns nothing

## Test plan
- [x] All 16 addon tests pass
- [ ] Deploy and verify more providers are queried
- [ ] Verify empty results are not cached (retry returns fresh scrape)
- [ ] Verify cached field reflects actual cache state
- [ ] Verify IMDB fallback works when cinemeta fails