### PR TITLE
Fix zero streams: content filter and quality filter bugs

### DIFF
--- a/addon/lib/filter.js
+++ b/addon/lib/filter.js
@@ -24,11 +24,11 @@ const SIZE_LIMITS = {
 export function applyFilters(streams, config) {
   let result = streams;
 
-  // 1. Quality whitelist
+  // 1. Quality whitelist (null/unknown quality always passes through)
   if (config.qualities?.length) {
     result = result.filter(s => {
       const q = extractQuality(s);
-      return config.qualities.includes(q);
+      return !q || config.qualities.includes(q);
     });
   }
 

--- a/scraper/providers/index.js
+++ b/scraper/providers/index.js
@@ -139,7 +139,7 @@ function filterByContent(records, meta) {
       const match = phraseRegex.exec(norm);
       if (!match) return false;
       const after = norm.slice(match.index + match[0].length).trim();
-      const nextWord = after.match(/^([a-z]+)/);
+      const nextWord = after.match(/^([a-z0-9]+)/);
       if (nextWord && !isTorrentMetadata(nextWord[1])) return false;
     } else {
       const matchCount = nameWords.filter(w =>


### PR DESCRIPTION
## Summary
- Fix scraper content filter rejecting most results for short titles (Succession, Ted, The Rookie) by including digits in the nextWord capture regex
- Fix addon quality filter dropping results with null/unknown quality when user has a quality whitelist configured

## Test plan
- [x] All 16 addon tests pass
- [ ] Deploy and verify streams return for The Rookie, Succession, Ted
- [ ] Flush Redis caches after deploy