### PR TITLE
Stop Stremio from caching empty stream responses

### DIFF
--- a/addon/addon.js
+++ b/addon/addon.js
@@ -64,8 +64,13 @@ export async function getAddonInterface(config) {
             return finalStreams;
           });
 
-          const cacheAge = streams.length ? CACHE_TTL_OK : CACHE_TTL_EMPTY;
-          resolve({ streams, cacheMaxAge: cacheAge, staleRevalidate: 3600, staleError: 14400 });
+          const hasStreams = streams.length > 0;
+          resolve({
+            streams,
+            cacheMaxAge: hasStreams ? CACHE_TTL_OK : CACHE_TTL_EMPTY,
+            staleRevalidate: hasStreams ? 3600 : 0,
+            staleError: hasStreams ? 14400 : 0,
+          });
         } catch (err) {
           logger.error(`Stream handler error [${id}]: ${err.message}`);
           resolve({ streams: [], cacheMaxAge: CACHE_TTL_ERROR });


### PR DESCRIPTION
## Summary
- Set staleRevalidate and staleError to 0 for empty stream results
- Previously, empty results used staleRevalidate=3600 and staleError=14400, letting Stremio serve stale "no streams" for up to 4 hours even after the server bug was fixed

## Test plan
- [x] All 16 addon tests pass
- [ ] Deploy and verify Stremio picks up new streams immediately