### PR TITLE
Add DuckDNS auto-update container for stable external access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@ PORT=7000
 LOG_LEVEL=info
 CACHE_TTL_STREAMS=3600
 
+# DuckDNS dynamic DNS (required for external access)
+DUCKDNS_TOKEN=your-duckdns-token
+DUCKDNS_SUBDOMAIN=magnetio
+
 METRICS_USER=admin
 METRICS_PASSWORD=changeme
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,6 +95,30 @@ jobs:
             --exclude '.DS_Store' \
             ./ "$DEPLOY_PATH/"
 
+      - name: Ensure DuckDNS token in .env
+        env:
+          DEPLOY_PATH: /home/peterdsp/magnetio
+          DUCKDNS_TOKEN: ${{ secrets.DUCKDNS_TOKEN }}
+        run: |
+          set -euo pipefail
+          cd "$DEPLOY_PATH"
+
+          if [ ! -f .env ]; then
+            cp .env.example .env
+            echo "Created .env from .env.example."
+          fi
+
+          if [ -n "${DUCKDNS_TOKEN:-}" ]; then
+            if grep -q '^DUCKDNS_TOKEN=' .env 2>/dev/null; then
+              sed -i "s|^DUCKDNS_TOKEN=.*|DUCKDNS_TOKEN=${DUCKDNS_TOKEN}|" .env
+            else
+              echo "DUCKDNS_TOKEN=${DUCKDNS_TOKEN}" >> .env
+            fi
+            echo "DuckDNS token configured."
+          else
+            echo "DUCKDNS_TOKEN secret not set; DuckDNS container will not start."
+          fi
+
       - name: Deploy with Docker Compose
         env:
           DEPLOY_PATH: /home/peterdsp/magnetio
@@ -102,11 +126,6 @@ jobs:
           set -euo pipefail
 
           cd "$DEPLOY_PATH"
-
-          if [ ! -f .env ]; then
-            cp .env.example .env
-            echo "Created .env from .env.example. Update it on the server before exposing the addon publicly."
-          fi
 
           docker compose up -d --build --remove-orphans
           docker compose ps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,22 @@ services:
       timeout: 5s
       retries: 3
 
+  # ─── DuckDNS Dynamic DNS ───────────────────────────────────────────────────
+  duckdns:
+    image: lscr.io/linuxserver/duckdns:latest
+    container_name: magnetio_duckdns
+    restart: unless-stopped
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/Athens
+      - SUBDOMAINS=${DUCKDNS_SUBDOMAIN:-magnetio}
+      - TOKEN=${DUCKDNS_TOKEN:?Set DUCKDNS_TOKEN in .env}
+      - UPDATE_IP=ipv4
+      - LOG_FILE=false
+    networks:
+      - magnetio_net
+
   # ─── Redis Cache ──────────────────────────────────────────────────────────
   redis:
     image: redis:7-alpine


### PR DESCRIPTION
## Summary
- Adds a linuxserver/duckdns container to docker-compose that auto-updates the public IP every 5 minutes
- Deploy workflow injects DUCKDNS_TOKEN from GitHub secrets into the Pi .env
- No more manual DNS updates or broken external access when the IP changes

## Setup
Add `DUCKDNS_TOKEN` to GitHub repo secrets (Settings > Secrets > Actions)

## Test plan
- [ ] Add DUCKDNS_TOKEN secret to repo
- [ ] Deploy and verify duckdns container starts
- [ ] Verify magnetio.duckdns.org resolves to correct IP