### PR TITLE
Fix deploy: make DuckDNS token optional

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       - PGID=1000
       - TZ=Europe/Athens
       - SUBDOMAINS=${DUCKDNS_SUBDOMAIN:-magnetio}
-      - TOKEN=${DUCKDNS_TOKEN:?Set DUCKDNS_TOKEN in .env}
+      - TOKEN=${DUCKDNS_TOKEN:-}
       - UPDATE_IP=ipv4
       - LOG_FILE=false
     networks:


### PR DESCRIPTION
## Summary
- Make DUCKDNS_TOKEN optional so deploy does not fail when the secret is not set
- The `:?` syntax causes docker compose to hard-fail; replaced with `:-` default

## Test plan
- [ ] Deploy workflow passes without DUCKDNS_TOKEN secret
- [ ] DuckDNS container starts normally when token IS provided