### PR TITLE
Add Torznab provider and optional Jackett/Prowlarr containers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,8 @@ OPENSUBTITLES_USER_AGENT=Magnetio v1.0.0
 # ALASS_PATH=alass
 SUBTITLE_SYNC_MAX_OFFSET_SECONDS=300
 ALASS_SPLIT_PENALTY=10
+
+# Optional: Jackett / Prowlarr (start with docker compose --profile jackett/prowlarr up)
+# JACKETT_PORT=9117
+# PROWLARR_PORT=9696
+# TZ=Etc/UTC

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ## What is Magnetio?
 
-Magnetio is an open-source, self-hostable **Stremio addon** that comes with its own **built-in torrent scraper**. It queries 21 torrent providers in parallel, deduplicates results, and optionally resolves them into **instant direct-download streams** through your debrid service of choice.
+Magnetio is an open-source, self-hostable **Stremio addon** that comes with its own **built-in torrent scraper**. It queries 22 torrent providers in parallel (including Torznab-compatible indexers via Jackett or Prowlarr), deduplicates results, and optionally resolves them into **instant direct-download streams** through your debrid service of choice.
 
 Everything runs on your own hardware (a Raspberry Pi is enough). No cloud subscriptions, no external scraper APIs, no data leaving your network.
 
@@ -30,7 +30,8 @@ Everything runs on your own hardware (a Raspberry Pi is enough). No cloud subscr
 |:---|:---:|:---:|
 | Fully in-house scraping | Yes | Depends on external APIs |
 | Self-hosted, private | Yes | Often cloud-hosted |
-| 21 torrent providers | Yes | Varies |
+| 22 torrent providers + Torznab | Yes | Varies |
+| Jackett / Prowlarr support | Yes | Rare |
 | 8 debrid services | Yes | 1-3 typically |
 | Background prewarm | Yes | No |
 | Per-user config (providers, quality, language) | Yes | Limited |
@@ -101,7 +102,7 @@ When a torrent is already cached on your debrid service, Stremio plays it as a d
 
 ## Supported Torrent Providers
 
-Magnetio ships with **21 providers** covering movies, TV series, and anime.
+Magnetio ships with **22 providers** covering movies, TV series, and anime, plus Torznab support for connecting external indexer managers.
 
 ### Movies and TV
 
@@ -133,6 +134,19 @@ Magnetio ships with **21 providers** covering movies, TV series, and anime.
 | SubsPlease | `subsplease` | JSON API (fansubs) |
 | AnimeTosho | `animetosho` | RSS feed (aggregator) |
 | nekoBT | `nekobt` | Torznab API (fansubs) |
+
+### Torznab / Jackett / Prowlarr
+
+| Provider | ID | Method |
+|:---|:---|:---|
+| Torznab | `torznab` | Torznab XML API (any compatible endpoint) |
+
+The Torznab provider is a universal connector that works with any Torznab-compatible indexer manager. Configure the API URL and key on the configure page. Magnetio will search all indexers you have set up in your Jackett or Prowlarr instance.
+
+- **[Jackett](https://github.com/Jackett/Jackett)** - translates queries to 500+ tracker-specific requests. Free, open-source (MIT).
+- **[Prowlarr](https://github.com/Prowlarr/Prowlarr)** - newer indexer manager with tighter *arr integration. Free, open-source (GPL-3.0).
+
+Both are available as optional Docker Compose services (see [Quick Start](#quick-start)).
 
 All providers run in parallel with a concurrency limit of 4 and a 22-second timeout. Results are deduplicated by `infoHash`, keeping the entry with the highest seeder count.
 
@@ -168,11 +182,17 @@ cd Magnetio
 # Start all three services (scraper + addon + redis)
 docker compose up -d
 
+# Optional: include Jackett for 500+ additional indexers
+docker compose --profile jackett up -d
+
+# Optional: include Prowlarr instead (or alongside)
+docker compose --profile prowlarr up -d
+
 # Open in browser
 open http://localhost:7000
 ```
 
-That is it. The addon runs on port 7000, the scraper on 8080, and Redis on 6379. All three services share a Docker bridge network.
+That is it. The addon runs on port 7000, the scraper on 8080, and Redis on 6379. Jackett runs on 9117 and Prowlarr on 9696 (both optional). All services share a Docker bridge network.
 
 ### Node.js (manual, two terminals)
 
@@ -202,9 +222,9 @@ Open `http://localhost:7000` to access the configuration page.
 
 Navigate to `http://your-server:7000` in a browser. The configuration page lets you:
 
-1. **Select torrent providers** to query
-2. **Set quality filters** (4K, 1080p, 720p, 480p, CAM)
-3. **Set language preferences** for streams and subtitles
+1. **Set quality filters** (4K, 1080p, 720p, 480p, CAM)
+2. **Set language preferences** for streams and subtitles
+3. **Connect Torznab indexers** (Jackett, Prowlarr, or any Torznab endpoint)
 4. **Enter debrid API keys** (with show/hide toggle)
 5. **Configure sort order and result limits**
 6. **Enable or disable background prewarm**
@@ -228,6 +248,8 @@ https://your-server:7000/providers=yts,eztv,1337x|sort=qualityseeders|limit=10|R
 | `qualities` | `4k`, `1080p`, `720p`, `480p`, `cam` | All | Quality whitelist |
 | `languages` | ISO codes (`en`, `es`, `pt`, `fr`, `de`, `it`, `ja`, `ru`, ...) | All | Stream language filter |
 | `subtitleLanguages` | ISO codes | `en` | Subtitle language preference |
+| `torznabUrl` | Full Torznab API URL | - | Torznab endpoint (Jackett/Prowlarr) |
+| `torznabKey` | API key | - | Torznab API key |
 | `prewarm` | `1`, `0`, `true`, `false` | `1` | Background-add top uncached torrents to debrid |
 | `prewarmLimit` | `0` to `10` | `3` | How many uncached results to prewarm per service |
 | `excludeSizes` | Size thresholds like `1GB,2GB` | None | Exclude streams below these sizes |
@@ -278,7 +300,8 @@ magnetio/
 |   |   +-- titleHelper.js         # Quality/codec/source/language/HDR parser
 |   +-- providers/
 |       |   index.js               # Parallel aggregator, deduplication, content filter
-|       |   yts.js                 # ...21 provider modules
+|       |   yts.js                 # ...21 built-in provider modules
+|       |   torznab.js             # Universal Torznab provider (Jackett/Prowlarr)
 |       +-- ...
 |
 +-- addon/                         # Stremio addon frontend
@@ -528,6 +551,22 @@ The `ADDON_PUBLIC_URL` environment variable controls what base URL appears in ma
 | `PREWARM_MOVIES` | `50` | Number of top movies to prewarm |
 | `PREWARM_SERIES` | `20` | Number of top series to prewarm |
 | `LOG_LEVEL` | `info` | Winston log level |
+
+### Optional Services
+
+| Variable | Default | Description |
+|:---|:---|:---|
+| `JACKETT_PORT` | `9117` | Exposed port for Jackett UI (profile: `jackett`) |
+| `PROWLARR_PORT` | `9696` | Exposed port for Prowlarr UI (profile: `prowlarr`) |
+| `TZ` | `Etc/UTC` | Timezone for Jackett/Prowlarr containers |
+
+Start optional services with Docker Compose profiles:
+
+```bash
+docker compose --profile jackett up -d                    # Jackett only
+docker compose --profile prowlarr up -d                   # Prowlarr only
+docker compose --profile jackett --profile prowlarr up -d # Both
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/Magnetio-v1.1.5-10b981?style=for-the-badge&labelColor=1a1a2e" alt="Version" />
+  <img src="https://img.shields.io/badge/Magnetio-v1.1.5-10b981?style=for-the-badge&labelColor=1a1a2e" alt="Magnetio Version" />
   <img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=for-the-badge&labelColor=1a1a2e" alt="License" />
   <img src="https://img.shields.io/badge/node-%3E%3D18-brightgreen?style=for-the-badge&logo=node.js&labelColor=1a1a2e" alt="Node.js" />
   <img src="https://img.shields.io/badge/docker-ready-2496ed?style=for-the-badge&logo=docker&labelColor=1a1a2e" alt="Docker" />
-  <img src="https://img.shields.io/badge/stremio-addon-7b5bf5?style=for-the-badge&labelColor=1a1a2e" alt="Stremio" />
+  <img src="https://img.shields.io/badge/stremio-addon-7b5bf5?style=for-the-badge&labelColor=1a1a2e" alt="Stremio Addon" />
+  <img src="https://img.shields.io/badge/debrid-8%20services-ff6b6b?style=for-the-badge&labelColor=1a1a2e" alt="Debrid Services" />
+  <img src="https://img.shields.io/badge/torznab-Jackett%20%2F%20Prowlarr-f5a623?style=for-the-badge&labelColor=1a1a2e" alt="Torznab Jackett Prowlarr" />
 </p>
 
 <h1 align="center">Magnetio</h1>
 
 <p align="center">
-  <strong>A fully self-hosted Stremio addon with built-in multi-provider torrent scraping and 8 debrid services.</strong>
+  <strong>A fully self-hosted Stremio addon with 22+ torrent providers, 8 debrid services, Torznab/Jackett/Prowlarr integration, and TMDB recommendations.</strong>
 </p>
 
 <p align="center">
-  No external scraper dependency. No third-party backend. Your API keys never leave your server.
+  No external scraper dependency. No third-party backend. Your API keys never leave your server.<br />
+  <a href="https://magnetio.peterdsp.dev">magnetio.peterdsp.dev</a> | <a href="https://magnetio.peterdsp.dev/configure">Configure and Install</a>
 </p>
 
 ---

--- a/addon/addon.js
+++ b/addon/addon.js
@@ -7,6 +7,7 @@ import { sortStreams } from './lib/sort.js';
 import { toStreamInfo } from './lib/streamInfo.js';
 import { getSubtitles } from './lib/subtitles.js';
 import { toStaticStream } from './moch/static.js';
+import { getSimilarContent } from './lib/similar.js';
 import NamedQueue from './lib/namedQueue.js';
 import pLimit from 'p-limit';
 import { logger } from './lib/logger.js';
@@ -84,6 +85,20 @@ export async function getAddonInterface(config) {
   // ─── CATALOG HANDLER ───────────────────────────────────────────────────────
   builder.defineCatalogHandler(async ({ type, id, extra }) => {
     try {
+      // Similar content recommendations (TMDB)
+      if (id.startsWith('magnetio_similar_')) {
+        const imdbId = extra?.genre || null;
+        if (!imdbId || !config.tmdbApiKey) {
+          return { metas: [], cacheMaxAge: CACHE_TTL_EMPTY };
+        }
+        const metas = await getSimilarContent(imdbId, type, config.tmdbApiKey);
+        return {
+          metas,
+          cacheMaxAge: metas.length ? 86400 : CACHE_TTL_EMPTY,
+        };
+      }
+
+      // Debrid library catalogs
       const skip = extra?.skip ? parseInt(extra.skip, 10) : 0;
       const metas = await getMochCatalog(id, type, config, skip);
       return { metas, cacheMaxAge: CACHE_TTL_OK };

--- a/addon/lib/configuration.js
+++ b/addon/lib/configuration.js
@@ -135,6 +135,9 @@ export function parseConfiguration(configString) {
       case 'pu':
         config.putioApiKey = value;
         break;
+      case 'tmdb':
+        config.tmdbApiKey = value;
+        break;
       case 'torznaburl':
         config.torznabUrl = decodeURIComponent(value);
         break;
@@ -180,6 +183,8 @@ export function getDefaultConfiguration() {
     prewarmLimit:       3,
     excludeSizes:       [],
     maxSize:            null,
+    // Recommendations (TMDB)
+    tmdbApiKey:         null,
     // Torznab (Jackett / Prowlarr)
     torznabUrl:         null,
     torznabApiKey:      null,

--- a/addon/lib/configuration.js
+++ b/addon/lib/configuration.js
@@ -139,16 +139,18 @@ export function parseConfiguration(configString) {
         config.tmdbApiKey = value;
         break;
       case 'torznaburl':
-        config.torznabUrl = decodeURIComponent(value);
+        try { config.torznabUrl = decodeURIComponent(value); }
+        catch { config.torznabUrl = value; }
         break;
       case 'torznabkey':
-        config.torznabApiKey = value;
+        try { config.torznabApiKey = decodeURIComponent(value); }
+        catch { config.torznabApiKey = value; }
         break;
     }
   }
 
-  if (config.torznabUrl && !config.providers.includes('torznab')) {
-    config.providers.push('torznab');
+  if (config.torznabUrl && !config.providers.includes(TorrentProvider.TORZNAB)) {
+    config.providers.push(TorrentProvider.TORZNAB);
   }
 
   return config;

--- a/addon/lib/configuration.js
+++ b/addon/lib/configuration.js
@@ -135,7 +135,17 @@ export function parseConfiguration(configString) {
       case 'pu':
         config.putioApiKey = value;
         break;
+      case 'torznaburl':
+        config.torznabUrl = decodeURIComponent(value);
+        break;
+      case 'torznabkey':
+        config.torznabApiKey = value;
+        break;
     }
+  }
+
+  if (config.torznabUrl && !config.providers.includes('torznab')) {
+    config.providers.push('torznab');
   }
 
   return config;
@@ -170,6 +180,9 @@ export function getDefaultConfiguration() {
     prewarmLimit:       3,
     excludeSizes:       [],
     maxSize:            null,
+    // Torznab (Jackett / Prowlarr)
+    torznabUrl:         null,
+    torznabApiKey:      null,
     // Debrid keys (all null by default)
     realDebridApiKey:   null,
     premiumizeApiKey:   null,

--- a/addon/lib/landingTemplate.js
+++ b/addon/lib/landingTemplate.js
@@ -78,42 +78,50 @@ export function landingTemplate(manifest, initialConfig = {}) {
   <title>${escapeHtml(manifest.name)} Configure</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Bitter:wght@400;500;700;800&family=Space+Mono:wght@400;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
   <style>
     [data-theme="dark"] {
-      --bg: #0f1117;
-      --surface: #1a1d27;
-      --border: #2a2d3a;
-      --text-primary: #e8eaed;
-      --text-secondary: #9ca3af;
-      --accent: #34d399;
-      --accent-hover: #6ee7b7;
-      --accent-subtle: rgba(52, 211, 153, 0.12);
-      --input-bg: #141620;
-      --chip-bg: #1e2130;
-      --chip-bg-active: rgba(52, 211, 153, 0.18);
-      --chip-border-active: #34d399;
-      --code-bg: #0d0f15;
-      --shadow: 0 1px 3px rgba(0,0,0,0.3);
-      --footer-bg: #1a1d27;
+      --bg: #0a0a0a;
+      --surface: #141414;
+      --surface-alt: #1a1a1a;
+      --border: rgba(255,255,255,0.08);
+      --text-primary: #e5e5e5;
+      --text-secondary: #888;
+      --text-muted: rgba(255,255,255,0.35);
+      --accent: #ffcfaa;
+      --accent-hover: #ffddc2;
+      --accent-subtle: rgba(255,207,170,0.1);
+      --accent-text: #0a0a0a;
+      --input-bg: #1a1a1a;
+      --chip-bg: #1e1e1e;
+      --chip-bg-active: rgba(255,207,170,0.15);
+      --chip-border-active: #ffcfaa;
+      --code-bg: #111;
+      --shadow: 0 2px 12px rgba(0,0,0,0.4);
+      --footer-bg: #141414;
+      --hero-bg: #111;
     }
 
     [data-theme="light"] {
-      --bg: #f8f9fb;
+      --bg: #fafafa;
       --surface: #ffffff;
-      --border: #e2e5eb;
-      --text-primary: #111827;
-      --text-secondary: #6b7280;
-      --accent: #10b981;
-      --accent-hover: #059669;
-      --accent-subtle: rgba(16, 185, 129, 0.1);
-      --input-bg: #f3f4f6;
-      --chip-bg: #f3f4f6;
-      --chip-bg-active: rgba(16, 185, 129, 0.12);
-      --chip-border-active: #10b981;
-      --code-bg: #f0f1f3;
-      --shadow: 0 1px 3px rgba(0,0,0,0.08);
-      --footer-bg: #ffffff;
+      --surface-alt: #f5f5f5;
+      --border: rgba(0,0,0,0.08);
+      --text-primary: #1a1a1a;
+      --text-secondary: #6b6b6b;
+      --text-muted: rgba(0,0,0,0.3);
+      --accent: #c47a4a;
+      --accent-hover: #a86535;
+      --accent-subtle: rgba(196,122,74,0.08);
+      --accent-text: #fff;
+      --input-bg: #f5f5f5;
+      --chip-bg: #f0f0f0;
+      --chip-bg-active: rgba(196,122,74,0.1);
+      --chip-border-active: #c47a4a;
+      --code-bg: #f0f0f0;
+      --shadow: 0 2px 12px rgba(0,0,0,0.06);
+      --footer-bg: #fff;
+      --hero-bg: #f0ece8;
     }
 
     * { box-sizing: border-box; margin: 0; }
@@ -123,74 +131,73 @@ export function landingTemplate(manifest, initialConfig = {}) {
       color: var(--text-primary);
       background: var(--bg);
       font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
-      padding: 32px 20px 48px;
       transition: background 0.2s, color 0.2s;
     }
 
     .shell {
-      max-width: 1100px;
-      margin: 0 auto;
       display: grid;
-      grid-template-columns: 1.2fr 0.8fr;
-      gap: 24px;
-      align-items: start;
+      grid-template-columns: 420px 1fr;
+      min-height: 100vh;
     }
 
-    .card {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 16px;
-      box-shadow: var(--shadow);
-      transition: background 0.2s, border-color 0.2s;
+    /* Left hero panel */
+    .hero-panel {
+      position: sticky;
+      top: 0;
+      height: 100vh;
+      background: var(--hero-bg);
+      padding: 48px 40px;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      overflow-y: auto;
+      border-right: 1px solid var(--border);
     }
 
-    /* Header */
-    .header {
-      padding: 24px 28px;
+    .hero-top { display: grid; gap: 48px; }
+
+    .hero-brand {
       display: flex;
       align-items: center;
       justify-content: space-between;
     }
 
-    .header-left {
+    .hero-brand-left {
       display: flex;
       align-items: center;
       gap: 12px;
     }
 
-    .header-logo {
-      width: 28px;
-      height: 28px;
-      border-radius: 6px;
+    .hero-logo {
+      width: 32px;
+      height: 32px;
+      border-radius: 8px;
     }
 
-    .header-title {
-      font-size: 1.1rem;
+    .hero-name {
+      font-family: "Bitter", serif;
       font-weight: 700;
-      letter-spacing: -0.02em;
+      font-size: 1.1rem;
     }
 
     .version-badge {
-      padding: 3px 10px;
-      border-radius: 999px;
-      background: var(--accent-subtle);
-      color: var(--accent);
-      font-size: 0.75rem;
-      font-weight: 600;
+      font-family: "Space Mono", monospace;
+      font-size: 0.7rem;
+      color: var(--text-muted);
     }
 
     .theme-toggle {
       width: 36px;
       height: 36px;
-      border-radius: 10px;
+      border-radius: 50%;
       border: 1px solid var(--border);
-      background: var(--input-bg);
+      background: transparent;
       color: var(--text-secondary);
       cursor: pointer;
       display: flex;
       align-items: center;
       justify-content: center;
-      transition: border-color 0.2s;
+      transition: all 0.2s;
     }
 
     .theme-toggle:hover {
@@ -198,45 +205,160 @@ export function landingTemplate(manifest, initialConfig = {}) {
       color: var(--accent);
     }
 
-    /* Hero */
-    .hero {
-      padding: 0 28px 28px;
+    .hero-headline {
+      font-family: "Bitter", serif;
+      font-weight: 800;
+      font-size: 2.8rem;
+      line-height: 1.1;
+      letter-spacing: -0.03em;
     }
 
-    .hero h1 {
-      font-size: 1.5rem;
-      font-weight: 700;
-      letter-spacing: -0.03em;
-      line-height: 1.3;
+    .hero-desc {
+      font-family: "Space Mono", monospace;
+      font-size: 0.85rem;
+      line-height: 1.7;
+      color: var(--text-secondary);
+      margin-top: 16px;
+    }
+
+    .hero-features {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      gap: 12px;
+      margin-top: 8px;
+    }
+
+    .feature {
+      padding: 16px;
+      border-radius: 12px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+    }
+
+    .feature-number {
+      font-family: "Bitter", serif;
+      font-weight: 800;
+      font-size: 2rem;
+      color: var(--text-muted);
+      line-height: 1;
+    }
+
+    .feature-label {
+      font-family: "Bitter", serif;
+      font-weight: 500;
+      font-size: 0.78rem;
+      color: var(--text-secondary);
+      margin-top: 4px;
+    }
+
+    .hero-bottom { display: grid; gap: 16px; }
+
+    .hero-install {
+      display: grid;
+      gap: 10px;
+    }
+
+    .preview {
+      padding: 14px;
+      border-radius: 12px;
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+    }
+
+    .preview-label {
+      font-family: "Space Mono", monospace;
+      color: var(--text-muted);
+      font-size: 0.65rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
       margin-bottom: 8px;
     }
 
-    .hero p {
-      color: var(--text-secondary);
-      font-size: 0.92rem;
+    .preview-code {
+      font-family: "Space Mono", monospace;
+      color: var(--accent);
+      word-break: break-all;
       line-height: 1.6;
+      font-size: 0.72rem;
     }
 
-    .stack { display: grid; gap: 20px; }
+    .btn {
+      width: 100%;
+      border: none;
+      border-radius: 40px;
+      padding: 16px 32px;
+      font-family: "Space Mono", monospace;
+      font-size: 0.85rem;
+      cursor: pointer;
+      transition: all 0.15s;
+      text-align: center;
+    }
 
-    /* Section cards */
-    .section {
-      padding: 24px 28px;
+    .btn:hover { opacity: 0.88; }
+
+    .btn-primary {
+      color: var(--accent-text);
+      background: var(--accent);
+      font-weight: 700;
+    }
+
+    .btn-secondary {
+      color: var(--text-primary);
+      background: transparent;
+      border: 1px solid var(--border);
+    }
+
+    .btn-secondary:hover { border-color: var(--accent); }
+
+    .status {
+      font-family: "Space Mono", monospace;
+      color: var(--accent);
+      font-size: 0.78rem;
+      min-height: 1.2rem;
+      text-align: center;
+    }
+
+    .footnote {
+      font-family: "Space Mono", monospace;
+      color: var(--text-muted);
+      font-size: 0.7rem;
+      text-align: center;
+      line-height: 1.5;
+    }
+
+    .footnote a { color: var(--accent); }
+
+    /* Right form panel */
+    .form-panel {
+      padding: 48px 40px;
+      overflow-y: auto;
       display: grid;
-      gap: 18px;
+      gap: 28px;
+      align-content: start;
+    }
+
+    .section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 28px;
+      display: grid;
+      gap: 20px;
+      box-shadow: var(--shadow);
     }
 
     .section-title {
-      font-size: 0.92rem;
-      font-weight: 600;
-      padding-left: 12px;
-      border-left: 3px solid var(--accent);
+      font-family: "Bitter", serif;
+      font-weight: 800;
+      font-size: 1.05rem;
+      letter-spacing: -0.01em;
     }
 
     .section-desc {
+      font-family: "Space Mono", monospace;
       color: var(--text-secondary);
-      font-size: 0.88rem;
-      line-height: 1.55;
+      font-size: 0.78rem;
+      line-height: 1.65;
     }
 
     .field-grid {
@@ -248,9 +370,9 @@ export function landingTemplate(manifest, initialConfig = {}) {
     label {
       display: grid;
       gap: 6px;
+      font-family: "Space Mono", monospace;
       color: var(--text-secondary);
-      font-size: 0.82rem;
-      font-weight: 500;
+      font-size: 0.75rem;
     }
 
     select, input[type="number"] {
@@ -260,17 +382,14 @@ export function landingTemplate(manifest, initialConfig = {}) {
       background: var(--input-bg);
       color: var(--text-primary);
       padding: 10px 12px;
-      font: inherit;
-      font-size: 0.88rem;
+      font-family: "Space Mono", monospace;
+      font-size: 0.82rem;
       outline: none;
       transition: border-color 0.15s;
     }
 
-    select:focus, input:focus {
-      border-color: var(--accent);
-    }
+    select:focus, input:focus { border-color: var(--accent); }
 
-    /* Chip grids */
     .chip-grid {
       display: flex;
       flex-wrap: wrap;
@@ -280,17 +399,18 @@ export function landingTemplate(manifest, initialConfig = {}) {
     .chip {
       cursor: pointer;
       display: inline-flex;
-      font-size: 0.82rem;
-      font-weight: 500;
+      font-size: 0.78rem;
     }
 
     .chip span {
       display: inline-block;
-      padding: 6px 14px;
+      padding: 7px 16px;
       border-radius: 999px;
       background: var(--chip-bg);
       border: 1px solid var(--border);
       color: var(--text-secondary);
+      font-family: "Space Mono", monospace;
+      font-size: 0.75rem;
       transition: all 0.15s;
       user-select: none;
     }
@@ -304,10 +424,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
 
     .chip input { display: none; }
 
-    /* Password fields */
-    .password-wrap {
-      position: relative;
-    }
+    .password-wrap { position: relative; }
 
     .password-wrap input {
       width: 100%;
@@ -316,15 +433,13 @@ export function landingTemplate(manifest, initialConfig = {}) {
       background: var(--input-bg);
       color: var(--text-primary);
       padding: 10px 40px 10px 12px;
-      font: inherit;
-      font-size: 0.88rem;
+      font-family: "Space Mono", monospace;
+      font-size: 0.82rem;
       outline: none;
       transition: border-color 0.15s;
     }
 
-    .password-wrap input:focus {
-      border-color: var(--accent);
-    }
+    .password-wrap input:focus { border-color: var(--accent); }
 
     .eye-toggle {
       position: absolute;
@@ -342,97 +457,8 @@ export function landingTemplate(manifest, initialConfig = {}) {
 
     .eye-toggle:hover { color: var(--accent); }
 
-    /* Summary sidebar */
-    .summary {
-      position: sticky;
-      top: 24px;
-      padding: 24px;
-      display: grid;
-      gap: 18px;
-    }
-
-    .summary h2 {
-      font-size: 1.1rem;
-      font-weight: 600;
-      letter-spacing: -0.02em;
-    }
-
-    .summary-desc {
-      color: var(--text-secondary);
-      font-size: 0.88rem;
-      line-height: 1.55;
-    }
-
-    .preview {
-      padding: 14px;
-      border-radius: 12px;
-      background: var(--code-bg);
-      border: 1px solid var(--border);
-    }
-
-    .preview-label {
-      color: var(--text-secondary);
-      font-size: 0.72rem;
-      font-weight: 600;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-      margin-bottom: 8px;
-    }
-
-    .preview-code {
-      font-family: "JetBrains Mono", monospace;
-      color: var(--accent);
-      word-break: break-all;
-      line-height: 1.6;
-      font-size: 0.8rem;
-    }
-
-    .actions { display: grid; gap: 10px; }
-
-    .btn {
-      width: 100%;
-      border: none;
-      border-radius: 12px;
-      padding: 12px 16px;
-      font: inherit;
-      font-size: 0.9rem;
-      font-weight: 600;
-      cursor: pointer;
-      transition: opacity 0.15s;
-    }
-
-    .btn:hover { opacity: 0.88; }
-
-    .btn-primary {
-      color: #fff;
-      background: var(--accent);
-    }
-
-    [data-theme="dark"] .btn-primary { color: #0f1117; }
-
-    .btn-secondary {
-      color: var(--text-primary);
-      background: transparent;
-      border: 1px solid var(--border);
-    }
-
-    .btn-secondary:hover {
-      border-color: var(--accent);
-    }
-
-    .status {
-      color: var(--accent);
-      font-size: 0.84rem;
-      min-height: 1.2rem;
-    }
-
-    .footnote {
-      color: var(--text-secondary);
-      font-size: 0.8rem;
-      line-height: 1.5;
-    }
-
-    .footnote a { color: var(--accent); }
+    /* Desktop summary (hidden, replaced by hero panel) */
+    .summary { display: none; }
 
     /* Mobile footer */
     .mobile-footer {
@@ -452,71 +478,127 @@ export function landingTemplate(manifest, initialConfig = {}) {
       gap: 10px;
     }
 
-    .mobile-footer .btn { flex: 1; padding: 11px 12px; font-size: 0.85rem; }
+    .mobile-footer .btn {
+      flex: 1;
+      padding: 12px 12px;
+      font-size: 0.8rem;
+      border-radius: 40px;
+    }
 
     .mobile-footer .footer-preview {
       margin-top: 8px;
       display: none;
     }
 
-    .mobile-footer .footer-preview.open {
-      display: block;
-    }
+    .mobile-footer .footer-preview.open { display: block; }
 
     .mobile-footer .preview-toggle {
       background: none;
       border: none;
+      font-family: "Space Mono", monospace;
       color: var(--text-secondary);
-      font-size: 0.78rem;
+      font-size: 0.72rem;
       cursor: pointer;
       padding: 6px 0 0;
       text-decoration: underline;
     }
 
     .mobile-footer .preview-code {
-      font-family: "JetBrains Mono", monospace;
+      font-family: "Space Mono", monospace;
       color: var(--accent);
       word-break: break-all;
-      font-size: 0.72rem;
+      font-size: 0.68rem;
       line-height: 1.5;
       margin-top: 6px;
     }
 
     @media (max-width: 980px) {
       .shell { grid-template-columns: 1fr; }
-      .summary { position: static; display: none; }
+      .hero-panel {
+        position: static;
+        height: auto;
+        padding: 32px 24px;
+        border-right: none;
+        border-bottom: 1px solid var(--border);
+      }
+      .hero-headline { font-size: 2rem; }
+      .hero-features { grid-template-columns: 1fr 1fr 1fr; }
+      .hero-install { display: none; }
       .mobile-footer { display: block; }
       body { padding-bottom: 90px; }
+      .form-panel { padding: 24px 16px; }
     }
 
     @media (max-width: 640px) {
-      body { padding: 16px 12px 90px; }
-      .header, .hero, .section { padding-left: 20px; padding-right: 20px; }
+      .hero-panel { padding: 24px 20px; }
+      .hero-headline { font-size: 1.6rem; }
+      .hero-desc { font-size: 0.78rem; }
+      .hero-features { grid-template-columns: 1fr; gap: 8px; }
+      .feature { padding: 12px; display: flex; align-items: center; gap: 12px; }
+      .feature-number { font-size: 1.4rem; }
+      .form-panel { padding: 16px 12px; }
+      .section { padding: 20px; }
       .field-grid { grid-template-columns: 1fr; }
     }
   </style>
 </head>
 <body>
   <div class="shell">
-    <div class="stack">
-      <div class="card">
-        <div class="header">
-          <div class="header-left">
-            <img class="header-logo" src="${escapeHtml(manifest.logo)}" alt="" />
-            <span class="header-title">${escapeHtml(manifest.name)}</span>
-            <span class="version-badge">v${escapeHtml(manifest.version)}</span>
+    <div class="hero-panel">
+      <div class="hero-top">
+        <div class="hero-brand">
+          <div class="hero-brand-left">
+            <img class="hero-logo" src="${escapeHtml(manifest.logo)}" alt="" />
+            <span class="hero-name">${escapeHtml(manifest.name)}</span>
           </div>
-          <button class="theme-toggle" id="themeToggle" type="button" title="Toggle theme">
-            ${SVG_MOON}
-          </button>
+          <div style="display:flex;align-items:center;gap:10px;">
+            <span class="version-badge">v${escapeHtml(manifest.version)}</span>
+            <button class="theme-toggle" id="themeToggle" type="button" title="Toggle theme">
+              ${SVG_MOON}
+            </button>
+          </div>
         </div>
-        <div class="hero">
-          <h1>Configure your addon</h1>
-          <p>Tune stream ranking, subtitle preferences and debrid services. The result is a manifest URL ready to install in Stremio.</p>
+
+        <div>
+          <h1 class="hero-headline">Stream everything, your way</h1>
+          <p class="hero-desc">Configure providers, debrid services and subtitles. Install the result in Stremio with one click.</p>
+        </div>
+
+        <div class="hero-features">
+          <div class="feature">
+            <div class="feature-number">01</div>
+            <div class="feature-label">Torznab indexers</div>
+          </div>
+          <div class="feature">
+            <div class="feature-number">02</div>
+            <div class="feature-label">Debrid services</div>
+          </div>
+          <div class="feature">
+            <div class="feature-number">03</div>
+            <div class="feature-label">Subtitle sync</div>
+          </div>
         </div>
       </div>
 
-      <section class="card section">
+      <div class="hero-bottom">
+        <div class="hero-install" id="desktopSummary">
+          <div class="preview">
+            <div class="preview-label">Manifest URL</div>
+            <div class="preview-code" id="manifestPreview"></div>
+          </div>
+          <button class="btn btn-primary" type="button" id="installBtn">Install in Stremio</button>
+          <button class="btn btn-secondary" type="button" id="copyBtn">Copy manifest URL</button>
+          <div class="status" id="status"></div>
+        </div>
+        <div class="footnote">
+          Magnetio does not host content.
+          <a href="https://github.com/peterdsp/Magnetio#disclaimer" target="_blank" rel="noreferrer">Read disclaimer</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="form-panel">
+      <section class="section">
         <h2 class="section-title">Stream Rules</h2>
         <div class="field-grid">
           <label>
@@ -554,7 +636,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
         </label>
       </section>
 
-      <section class="card section">
+      <section class="section">
         <h2 class="section-title">Subtitles</h2>
         <p class="section-desc">Select every subtitle language you want returned. Magnetio provides a dedicated Stremio subtitles resource.</p>
         <label>
@@ -565,7 +647,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
         </label>
       </section>
 
-      <section class="card section">
+      <section class="section">
         <h2 class="section-title">Torznab / Jackett / Prowlarr</h2>
         <p class="section-desc">Connect a Torznab-compatible indexer manager. Enter the full Torznab API URL and your API key.</p>
         <div class="field-grid">
@@ -585,7 +667,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
         </div>
       </section>
 
-      <section class="card section">
+      <section class="section">
         <h2 class="section-title">Debrid Services</h2>
         <p class="section-desc">Add API keys for your debrid services. Cached torrents resolve as direct streams automatically.</p>
         <div class="field-grid">
@@ -619,29 +701,6 @@ export function landingTemplate(manifest, initialConfig = {}) {
         </div>
       </section>
     </div>
-
-    <aside class="card summary" id="desktopSummary">
-      <div>
-        <h2>Install Target</h2>
-        <p class="summary-desc">This is the manifest URL Stremio will install. Re-open from a configured URL to adjust settings later.</p>
-      </div>
-
-      <div class="preview">
-        <div class="preview-label">Manifest URL</div>
-        <div class="preview-code" id="manifestPreview"></div>
-      </div>
-
-      <div class="actions">
-        <button class="btn btn-primary" type="button" id="installBtn">Install in Stremio</button>
-        <button class="btn btn-secondary" type="button" id="copyBtn">Copy manifest URL</button>
-      </div>
-
-      <div class="status" id="status"></div>
-      <div class="footnote">
-        Magnetio does not host content.
-        <a href="https://github.com/Magnetio/magnetio#disclaimer" target="_blank" rel="noreferrer">Read disclaimer</a>
-      </div>
-    </aside>
   </div>
 
   <div class="mobile-footer" id="mobileFooter">

--- a/addon/lib/landingTemplate.js
+++ b/addon/lib/landingTemplate.js
@@ -76,309 +76,451 @@ export function landingTemplate(manifest, initialConfig = {}) {
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>${escapeHtml(manifest.name)} Configure</title>
+  <title>${escapeHtml(manifest.name)} - Stream Anything</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Bitter:wght@400;500;700;800&family=Space+Mono:wght@400;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
   <style>
-    [data-theme="dark"] {
-      --bg: #0a0a0a;
-      --surface: #141414;
-      --surface-alt: #1a1a1a;
+    html { scroll-behavior: smooth; }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #06070a;
+      --surface: rgba(255,255,255,0.04);
+      --surface-solid: #0d0e12;
       --border: rgba(255,255,255,0.08);
-      --text-primary: #e5e5e5;
-      --text-secondary: #888;
-      --text-muted: rgba(255,255,255,0.35);
-      --accent: #ffcfaa;
-      --accent-hover: #ffddc2;
-      --accent-subtle: rgba(255,207,170,0.1);
-      --accent-text: #0a0a0a;
-      --input-bg: #1a1a1a;
-      --chip-bg: #1e1e1e;
-      --chip-bg-active: rgba(255,207,170,0.15);
-      --chip-border-active: #ffcfaa;
-      --code-bg: #111;
-      --shadow: 0 2px 12px rgba(0,0,0,0.4);
-      --footer-bg: #141414;
-      --hero-bg: #111;
+      --border-hover: rgba(255,255,255,0.15);
+      --text-primary: #e2e8f0;
+      --text-secondary: #94a3b8;
+      --text-muted: rgba(255,255,255,0.3);
+      --accent: #a78bfa;
+      --accent-hover: #c4b5fd;
+      --gradient-start: #667eea;
+      --gradient-end: #764ba2;
+      --success: #34d399;
+      --input-bg: rgba(255,255,255,0.05);
+      --chip-bg: rgba(255,255,255,0.06);
+      --chip-bg-active: rgba(167,139,250,0.15);
+      --chip-border-active: #a78bfa;
+      --code-bg: rgba(0,0,0,0.4);
     }
-
-    [data-theme="light"] {
-      --bg: #fafafa;
-      --surface: #ffffff;
-      --surface-alt: #f5f5f5;
-      --border: rgba(0,0,0,0.08);
-      --text-primary: #1a1a1a;
-      --text-secondary: #6b6b6b;
-      --text-muted: rgba(0,0,0,0.3);
-      --accent: #c47a4a;
-      --accent-hover: #a86535;
-      --accent-subtle: rgba(196,122,74,0.08);
-      --accent-text: #fff;
-      --input-bg: #f5f5f5;
-      --chip-bg: #f0f0f0;
-      --chip-bg-active: rgba(196,122,74,0.1);
-      --chip-border-active: #c47a4a;
-      --code-bg: #f0f0f0;
-      --shadow: 0 2px 12px rgba(0,0,0,0.06);
-      --footer-bg: #fff;
-      --hero-bg: #f0ece8;
-    }
-
-    * { box-sizing: border-box; margin: 0; }
 
     body {
       min-height: 100vh;
       color: var(--text-primary);
       background: var(--bg);
       font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
-      transition: background 0.2s, color 0.2s;
+      overflow-x: hidden;
     }
 
-    .shell {
-      display: grid;
-      grid-template-columns: 420px 1fr;
-      min-height: 100vh;
-    }
-
-    /* Left hero panel */
-    .hero-panel {
-      position: sticky;
+    /* ---- Navbar ---- */
+    .navbar {
+      position: fixed;
       top: 0;
-      height: 100vh;
-      background: var(--hero-bg);
-      padding: 48px 40px;
-      display: flex;
-      flex-direction: column;
-      justify-content: space-between;
-      overflow-y: auto;
-      border-right: 1px solid var(--border);
-    }
-
-    .hero-top { display: grid; gap: 48px; }
-
-    .hero-brand {
+      left: 0;
+      right: 0;
+      z-index: 1000;
+      padding: 0 32px;
+      height: 64px;
       display: flex;
       align-items: center;
       justify-content: space-between;
+      background: rgba(6,7,10,0.8);
+      backdrop-filter: blur(20px);
+      border-bottom: 1px solid var(--border);
     }
 
-    .hero-brand-left {
+    .nav-left {
       display: flex;
       align-items: center;
       gap: 12px;
     }
 
-    .hero-logo {
-      width: 32px;
-      height: 32px;
-      border-radius: 8px;
+    .nav-brand {
+      font-weight: 800;
+      font-size: 1.15rem;
+      letter-spacing: -0.04em;
+      background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
     }
 
-    .hero-name {
-      font-family: "Bitter", serif;
-      font-weight: 700;
-      font-size: 1.1rem;
-    }
-
-    .version-badge {
-      font-family: "Space Mono", monospace;
+    .nav-version {
+      font-family: "JetBrains Mono", monospace;
       font-size: 0.7rem;
       color: var(--text-muted);
+      background: var(--surface);
+      border: 1px solid var(--border);
+      padding: 3px 10px;
+      border-radius: 999px;
     }
 
-    .theme-toggle {
-      width: 36px;
-      height: 36px;
-      border-radius: 50%;
-      border: 1px solid var(--border);
-      background: transparent;
-      color: var(--text-secondary);
+    .nav-cta {
+      display: inline-flex;
+      align-items: center;
+      padding: 8px 22px;
+      border-radius: 999px;
+      border: none;
+      background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
+      color: #fff;
+      font-family: "Inter", sans-serif;
+      font-weight: 600;
+      font-size: 0.85rem;
       cursor: pointer;
+      transition: opacity 0.2s, transform 0.2s;
+      text-decoration: none;
+    }
+
+    .nav-cta:hover { opacity: 0.9; transform: translateY(-1px); }
+
+    /* ---- Hero ---- */
+    .hero {
+      position: relative;
+      min-height: 100vh;
       display: flex;
+      flex-direction: column;
       align-items: center;
       justify-content: center;
-      transition: all 0.2s;
-    }
-
-    .theme-toggle:hover {
-      border-color: var(--accent);
-      color: var(--accent);
-    }
-
-    .hero-headline {
-      font-family: "Bitter", serif;
-      font-weight: 800;
-      font-size: 2.8rem;
-      line-height: 1.1;
-      letter-spacing: -0.03em;
-    }
-
-    .hero-headline em {
-      font-style: italic;
-      font-weight: 400;
-      color: var(--text-muted);
-    }
-
-    .hero-desc {
-      font-family: "Space Mono", monospace;
-      font-size: 0.85rem;
-      line-height: 1.7;
-      color: var(--text-secondary);
-      margin-top: 16px;
-    }
-
-    .hero-features {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 0;
-      margin-top: 8px;
-      border-radius: 16px;
-      border: 1px solid var(--border);
-      background: var(--surface);
-      backdrop-filter: blur(6px);
+      text-align: center;
+      padding: 120px 24px 80px;
       overflow: hidden;
     }
 
-    .feature {
-      padding: 16px 20px;
-      border-bottom: 1px solid var(--border);
+    .hero-orb {
+      position: absolute;
+      border-radius: 50%;
+      filter: blur(120px);
+      opacity: 0.3;
+      pointer-events: none;
     }
 
-    .feature:nth-child(odd) {
-      border-right: 1px solid var(--border);
+    .hero-orb-1 {
+      width: 600px;
+      height: 600px;
+      background: radial-gradient(circle, var(--gradient-start), transparent 70%);
+      top: -200px;
+      left: -100px;
+      animation: floatOrb1 20s ease-in-out infinite;
     }
 
-    .feature:nth-last-child(-n+2) {
-      border-bottom: none;
+    .hero-orb-2 {
+      width: 500px;
+      height: 500px;
+      background: radial-gradient(circle, var(--gradient-end), transparent 70%);
+      bottom: -150px;
+      right: -100px;
+      animation: floatOrb2 25s ease-in-out infinite;
     }
 
-    .feature-number {
-      font-family: "Bitter", serif;
+    .hero-orb-3 {
+      width: 350px;
+      height: 350px;
+      background: radial-gradient(circle, var(--accent), transparent 70%);
+      top: 40%;
+      left: 50%;
+      transform: translateX(-50%);
+      animation: floatOrb3 18s ease-in-out infinite;
+      opacity: 0.15;
+    }
+
+    @keyframes floatOrb1 {
+      0%, 100% { transform: translate(0, 0); }
+      33% { transform: translate(60px, 40px); }
+      66% { transform: translate(-40px, 20px); }
+    }
+
+    @keyframes floatOrb2 {
+      0%, 100% { transform: translate(0, 0); }
+      33% { transform: translate(-50px, -30px); }
+      66% { transform: translate(30px, -50px); }
+    }
+
+    @keyframes floatOrb3 {
+      0%, 100% { transform: translateX(-50%) scale(1); }
+      50% { transform: translateX(-50%) scale(1.2); }
+    }
+
+    .hero-content {
+      position: relative;
+      z-index: 1;
+      max-width: 800px;
+    }
+
+    .hero-headline {
       font-weight: 800;
-      font-size: 1.6rem;
+      font-size: 4rem;
+      line-height: 1.08;
+      letter-spacing: -0.04em;
+      margin-bottom: 24px;
+    }
+
+    .hero-headline .gradient-text {
+      background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end), var(--accent));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .hero-sub {
+      font-size: 1.15rem;
+      line-height: 1.7;
+      color: var(--text-secondary);
+      max-width: 560px;
+      margin: 0 auto 40px;
+    }
+
+    .hero-buttons {
+      display: flex;
+      gap: 16px;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+
+    .btn-hero-primary {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 14px 32px;
+      border-radius: 999px;
+      border: none;
+      background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
+      color: #fff;
+      font-family: "Inter", sans-serif;
+      font-weight: 700;
+      font-size: 1rem;
+      cursor: pointer;
+      transition: opacity 0.2s, transform 0.2s;
+      text-decoration: none;
+    }
+
+    .btn-hero-primary:hover { opacity: 0.9; transform: translateY(-2px); }
+
+    .btn-hero-secondary {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 14px 32px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: transparent;
       color: var(--text-primary);
+      font-family: "Inter", sans-serif;
+      font-weight: 600;
+      font-size: 1rem;
+      cursor: pointer;
+      transition: all 0.2s;
+      text-decoration: none;
+    }
+
+    .btn-hero-secondary:hover { border-color: var(--accent); color: var(--accent); }
+
+    /* ---- Stats Bar ---- */
+    .stats-bar {
+      display: flex;
+      justify-content: center;
+      gap: 0;
+      padding: 0 24px;
+      max-width: 960px;
+      margin: -40px auto 0;
+      position: relative;
+      z-index: 2;
+    }
+
+    .stat-item {
+      flex: 1;
+      text-align: center;
+      padding: 32px 24px;
+      background: var(--surface);
+      backdrop-filter: blur(12px);
+      border: 1px solid var(--border);
+      border-right: none;
+    }
+
+    .stat-item:first-child { border-radius: 16px 0 0 16px; }
+    .stat-item:last-child { border-radius: 0 16px 16px 0; border-right: 1px solid var(--border); }
+
+    .stat-number {
+      font-weight: 800;
+      font-size: 2rem;
+      letter-spacing: -0.04em;
+      color: var(--success);
       line-height: 1;
     }
 
-    .feature-label {
-      font-family: "Space Mono", monospace;
-      font-weight: 400;
-      font-size: 0.7rem;
+    .stat-label {
+      font-size: 0.78rem;
       color: var(--text-secondary);
-      margin-top: 6px;
-      line-height: 1.4;
+      margin-top: 8px;
     }
 
-    .hero-bottom { display: grid; gap: 16px; }
-
-    .hero-install {
-      display: grid;
-      gap: 10px;
+    /* ---- Section container ---- */
+    .page-section {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 100px 24px;
+      opacity: 0;
+      transform: translateY(30px);
+      transition: opacity 0.7s ease-out, transform 0.7s ease-out;
     }
 
-    .preview {
-      padding: 14px;
-      border-radius: 12px;
-      background: var(--code-bg);
-      border: 1px solid var(--border);
+    .page-section.visible {
+      opacity: 1;
+      transform: translateY(0);
     }
 
-    .preview-label {
-      font-family: "Space Mono", monospace;
-      color: var(--text-muted);
-      font-size: 0.65rem;
-      letter-spacing: 0.08em;
+    .section-label {
+      font-family: "JetBrains Mono", monospace;
+      font-size: 0.75rem;
+      letter-spacing: 0.12em;
       text-transform: uppercase;
-      margin-bottom: 8px;
-    }
-
-    .preview-code {
-      font-family: "Space Mono", monospace;
       color: var(--accent);
-      word-break: break-all;
-      line-height: 1.6;
-      font-size: 0.72rem;
+      margin-bottom: 12px;
     }
 
-    .btn {
-      width: 100%;
-      border: none;
-      border-radius: 40px;
-      padding: 16px 32px;
-      font-family: "Space Mono", monospace;
-      font-size: 0.85rem;
-      cursor: pointer;
-      transition: all 0.15s;
-      text-align: center;
-    }
-
-    .btn:hover { opacity: 0.88; }
-
-    .btn-primary {
-      color: var(--accent-text);
-      background: var(--accent);
-      font-weight: 700;
-    }
-
-    .btn-secondary {
-      color: var(--text-primary);
-      background: transparent;
-      border: 1px solid var(--border);
-    }
-
-    .btn-secondary:hover { border-color: var(--accent); }
-
-    .status {
-      font-family: "Space Mono", monospace;
-      color: var(--accent);
-      font-size: 0.78rem;
-      min-height: 1.2rem;
-      text-align: center;
-    }
-
-    .footnote {
-      font-family: "Space Mono", monospace;
-      color: var(--text-muted);
-      font-size: 0.7rem;
-      text-align: center;
-      line-height: 1.5;
-    }
-
-    .footnote a { color: var(--accent); }
-
-    /* Right form panel */
-    .form-panel {
-      padding: 48px 40px;
-      overflow-y: auto;
-      display: grid;
-      gap: 28px;
-      align-content: start;
-    }
-
-    .section {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 16px;
-      padding: 28px;
-      display: grid;
-      gap: 20px;
-      box-shadow: var(--shadow);
-    }
-
-    .section-title {
-      font-family: "Bitter", serif;
+    .section-heading {
       font-weight: 800;
-      font-size: 1.05rem;
-      letter-spacing: -0.01em;
+      font-size: 2.4rem;
+      letter-spacing: -0.04em;
+      margin-bottom: 16px;
     }
 
-    .section-desc {
-      font-family: "Space Mono", monospace;
+    .section-sub {
+      font-size: 1.05rem;
       color: var(--text-secondary);
-      font-size: 0.78rem;
+      line-height: 1.7;
+      max-width: 600px;
+      margin-bottom: 48px;
+    }
+
+    /* ---- Features Grid ---- */
+    .features-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 20px;
+    }
+
+    .feature-card {
+      background: var(--surface);
+      backdrop-filter: blur(12px);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      padding: 32px 28px;
+      transition: border-color 0.3s, box-shadow 0.3s;
+    }
+
+    .feature-card:hover {
+      border-color: var(--border-hover);
+      box-shadow: 0 0 30px rgba(102,126,234,0.08);
+    }
+
+    .feature-icon {
+      font-size: 2rem;
+      margin-bottom: 20px;
+      display: block;
+    }
+
+    .feature-title {
+      font-weight: 700;
+      font-size: 1.1rem;
+      letter-spacing: -0.02em;
+      margin-bottom: 10px;
+    }
+
+    .feature-desc {
+      font-size: 0.88rem;
+      color: var(--text-secondary);
       line-height: 1.65;
     }
+
+    /* ---- How It Works ---- */
+    .how-steps {
+      display: flex;
+      gap: 0;
+      align-items: flex-start;
+      position: relative;
+    }
+
+    .how-step {
+      flex: 1;
+      text-align: center;
+      padding: 0 24px;
+      position: relative;
+    }
+
+    .how-step-number {
+      width: 56px;
+      height: 56px;
+      border-radius: 50%;
+      background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
+      color: #fff;
+      font-weight: 800;
+      font-size: 1.2rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto 20px;
+      position: relative;
+      z-index: 1;
+    }
+
+    .how-step-line {
+      position: absolute;
+      top: 28px;
+      left: calc(50% + 28px);
+      width: calc(100% - 56px);
+      height: 2px;
+      background: linear-gradient(90deg, var(--gradient-start), var(--gradient-end));
+      opacity: 0.3;
+    }
+
+    .how-step:last-child .how-step-line { display: none; }
+
+    .how-step-title {
+      font-weight: 700;
+      font-size: 1.15rem;
+      letter-spacing: -0.02em;
+      margin-bottom: 10px;
+    }
+
+    .how-step-desc {
+      font-size: 0.88rem;
+      color: var(--text-secondary);
+      line-height: 1.6;
+    }
+
+    /* ---- Configure Section ---- */
+    .configure-section {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 100px 24px;
+    }
+
+    .config-card {
+      background: var(--surface);
+      backdrop-filter: blur(12px);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      padding: 32px;
+      margin-bottom: 24px;
+      display: grid;
+      gap: 20px;
+    }
+
+    .config-card-title {
+      font-weight: 700;
+      font-size: 1.1rem;
+      letter-spacing: -0.02em;
+    }
+
+    .config-card-desc {
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+      line-height: 1.65;
+    }
+
+    .config-card-desc a { color: var(--accent); }
 
     .field-grid {
       display: grid;
@@ -389,22 +531,21 @@ export function landingTemplate(manifest, initialConfig = {}) {
     label {
       display: grid;
       gap: 6px;
-      font-family: "Space Mono", monospace;
+      font-size: 0.78rem;
       color: var(--text-secondary);
-      font-size: 0.75rem;
     }
 
     select, input[type="number"] {
       width: 100%;
       border: 1px solid var(--border);
-      border-radius: 10px;
+      border-radius: 12px;
       background: var(--input-bg);
       color: var(--text-primary);
-      padding: 10px 12px;
-      font-family: "Space Mono", monospace;
+      padding: 11px 14px;
+      font-family: "JetBrains Mono", monospace;
       font-size: 0.82rem;
       outline: none;
-      transition: border-color 0.15s;
+      transition: border-color 0.2s;
     }
 
     select:focus, input:focus { border-color: var(--accent); }
@@ -428,9 +569,9 @@ export function landingTemplate(manifest, initialConfig = {}) {
       background: var(--chip-bg);
       border: 1px solid var(--border);
       color: var(--text-secondary);
-      font-family: "Space Mono", monospace;
+      font-family: "JetBrains Mono", monospace;
       font-size: 0.75rem;
-      transition: all 0.15s;
+      transition: all 0.2s;
       user-select: none;
     }
 
@@ -448,14 +589,14 @@ export function landingTemplate(manifest, initialConfig = {}) {
     .password-wrap input {
       width: 100%;
       border: 1px solid var(--border);
-      border-radius: 10px;
+      border-radius: 12px;
       background: var(--input-bg);
       color: var(--text-primary);
-      padding: 10px 40px 10px 12px;
-      font-family: "Space Mono", monospace;
+      padding: 11px 40px 11px 14px;
+      font-family: "JetBrains Mono", monospace;
       font-size: 0.82rem;
       outline: none;
-      transition: border-color 0.15s;
+      transition: border-color 0.2s;
     }
 
     .password-wrap input:focus { border-color: var(--accent); }
@@ -476,17 +617,107 @@ export function landingTemplate(manifest, initialConfig = {}) {
 
     .eye-toggle:hover { color: var(--accent); }
 
-    /* Desktop summary (hidden, replaced by hero panel) */
-    .summary { display: none; }
+    /* ---- Install Bar ---- */
+    .install-bar {
+      max-width: 800px;
+      margin: 0 auto 60px;
+      padding: 0 24px;
+    }
 
-    /* Mobile footer */
+    .install-card {
+      background: var(--surface);
+      backdrop-filter: blur(12px);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      padding: 32px;
+      display: grid;
+      gap: 16px;
+    }
+
+    .install-card-label {
+      font-family: "JetBrains Mono", monospace;
+      font-size: 0.7rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+    }
+
+    .install-card-url {
+      font-family: "JetBrains Mono", monospace;
+      color: var(--accent);
+      word-break: break-all;
+      line-height: 1.6;
+      font-size: 0.75rem;
+    }
+
+    .install-card-actions {
+      display: flex;
+      gap: 12px;
+    }
+
+    .btn {
+      border: none;
+      border-radius: 999px;
+      padding: 14px 28px;
+      font-family: "Inter", sans-serif;
+      font-weight: 600;
+      font-size: 0.88rem;
+      cursor: pointer;
+      transition: all 0.2s;
+      text-align: center;
+      flex: 1;
+    }
+
+    .btn:hover { opacity: 0.88; }
+
+    .btn-primary {
+      color: #fff;
+      background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
+    }
+
+    .btn-primary:hover { transform: translateY(-1px); }
+
+    .btn-secondary {
+      color: var(--text-primary);
+      background: transparent;
+      border: 1px solid var(--border);
+    }
+
+    .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+
+    .status {
+      font-family: "JetBrains Mono", monospace;
+      color: var(--accent);
+      font-size: 0.78rem;
+      min-height: 1.2rem;
+      text-align: center;
+    }
+
+    /* ---- Footer ---- */
+    .site-footer {
+      border-top: 1px solid var(--border);
+      padding: 40px 24px;
+      text-align: center;
+    }
+
+    .footer-text {
+      font-size: 0.82rem;
+      color: var(--text-secondary);
+      line-height: 1.8;
+    }
+
+    .footer-text a { color: var(--accent); text-decoration: none; }
+    .footer-text a:hover { text-decoration: underline; }
+
+    /* ---- Mobile footer ---- */
     .mobile-footer {
       display: none;
       position: fixed;
       bottom: 0;
       left: 0;
       right: 0;
-      background: var(--footer-bg);
+      background: rgba(6,7,10,0.95);
+      backdrop-filter: blur(20px);
       border-top: 1px solid var(--border);
       padding: 12px 16px;
       z-index: 100;
@@ -501,7 +732,6 @@ export function landingTemplate(manifest, initialConfig = {}) {
       flex: 1;
       padding: 12px 12px;
       font-size: 0.8rem;
-      border-radius: 40px;
     }
 
     .mobile-footer .footer-preview {
@@ -514,7 +744,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
     .mobile-footer .preview-toggle {
       background: none;
       border: none;
-      font-family: "Space Mono", monospace;
+      font-family: "JetBrains Mono", monospace;
       color: var(--text-secondary);
       font-size: 0.72rem;
       cursor: pointer;
@@ -523,7 +753,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
     }
 
     .mobile-footer .preview-code {
-      font-family: "Space Mono", monospace;
+      font-family: "JetBrains Mono", monospace;
       color: var(--accent);
       word-break: break-all;
       font-size: 0.68rem;
@@ -531,214 +761,309 @@ export function landingTemplate(manifest, initialConfig = {}) {
       margin-top: 6px;
     }
 
+    /* ---- Responsive ---- */
     @media (max-width: 980px) {
-      .shell { grid-template-columns: 1fr; }
-      .hero-panel {
-        position: static;
-        height: auto;
-        padding: 32px 24px;
-        border-right: none;
-        border-bottom: 1px solid var(--border);
-      }
-      .hero-headline { font-size: 2rem; }
-      .hero-features { grid-template-columns: 1fr 1fr; }
-      .hero-install { display: none; }
+      .hero-headline { font-size: 2.8rem; }
+      .features-grid { grid-template-columns: repeat(2, 1fr); }
+      .stats-bar { flex-wrap: wrap; margin-top: 0; }
+      .stat-item { flex: 1 1 45%; }
+      .stat-item:first-child { border-radius: 16px 0 0 0; }
+      .stat-item:nth-child(2) { border-radius: 0 16px 0 0; border-right: 1px solid var(--border); }
+      .stat-item:nth-child(3) { border-radius: 0 0 0 16px; }
+      .stat-item:last-child { border-radius: 0 0 16px 0; }
+      .how-steps { flex-direction: column; gap: 32px; }
+      .how-step { text-align: left; display: flex; gap: 20px; align-items: flex-start; padding: 0; }
+      .how-step-number { margin: 0; flex-shrink: 0; }
+      .how-step-line { display: none !important; }
+      .install-bar { display: none; }
       .mobile-footer { display: block; }
       body { padding-bottom: 90px; }
-      .form-panel { padding: 24px 16px; }
     }
 
     @media (max-width: 640px) {
-      .hero-panel { padding: 24px 20px; }
-      .hero-headline { font-size: 1.6rem; }
-      .hero-desc { font-size: 0.78rem; }
-      .hero-features { grid-template-columns: 1fr 1fr; }
-      .feature { padding: 12px 16px; }
-      .feature-number { font-size: 1.2rem; }
-      .form-panel { padding: 16px 12px; }
-      .section { padding: 20px; }
+      .navbar { padding: 0 16px; }
+      .nav-version { display: none; }
+      .hero { padding: 100px 16px 60px; }
+      .hero-headline { font-size: 2rem; }
+      .hero-sub { font-size: 0.95rem; }
+      .features-grid { grid-template-columns: 1fr; }
+      .section-heading { font-size: 1.8rem; }
       .field-grid { grid-template-columns: 1fr; }
+      .config-card { padding: 24px 20px; }
+      .page-section { padding: 60px 16px; }
+      .configure-section { padding: 60px 16px; }
     }
   </style>
 </head>
 <body>
-  <div class="shell">
-    <div class="hero-panel">
-      <div class="hero-top">
-        <div class="hero-brand">
-          <div class="hero-brand-left">
-            <span class="hero-name">${escapeHtml(manifest.name)}</span>
-          </div>
-          <div style="display:flex;align-items:center;gap:10px;">
-            <span class="version-badge">v${escapeHtml(manifest.version)}</span>
-            <button class="theme-toggle" id="themeToggle" type="button" title="Toggle theme">
-              ${SVG_MOON}
-            </button>
-          </div>
-        </div>
 
-        <div>
-          <h1 class="hero-headline">Stream <em>your</em> own way</h1>
-          <p class="hero-desc">Configure providers, debrid services and subtitles. Install the result in Stremio with one click.</p>
-        </div>
+  <!-- Navbar -->
+  <nav class="navbar">
+    <div class="nav-left">
+      <span class="nav-brand">${escapeHtml(manifest.name)}</span>
+      <span class="nav-version">v${escapeHtml(manifest.version)}</span>
+    </div>
+    <a href="#configure" class="nav-cta">Configure</a>
+  </nav>
 
-        <div class="hero-features">
-          <div class="feature">
-            <div class="feature-number">8+</div>
-            <div class="feature-label">Debrid services supported</div>
-          </div>
-          <div class="feature">
-            <div class="feature-number">15</div>
-            <div class="feature-label">Subtitle languages</div>
-          </div>
-          <div class="feature">
-            <div class="feature-number">5</div>
-            <div class="feature-label">Quality tiers</div>
-          </div>
-          <div class="feature">
-            <div class="feature-number">1-click</div>
-            <div class="feature-label">Stremio install</div>
-          </div>
-        </div>
-      </div>
-
-      <div class="hero-bottom">
-        <div class="hero-install" id="desktopSummary">
-          <div class="preview">
-            <div class="preview-label">Manifest URL</div>
-            <div class="preview-code" id="manifestPreview"></div>
-          </div>
-          <button class="btn btn-primary" type="button" id="installBtn">Install in Stremio</button>
-          <button class="btn btn-secondary" type="button" id="copyBtn">Copy manifest URL</button>
-          <div class="status" id="status"></div>
-        </div>
-        <div class="footnote">
-          Magnetio does not host content.
-          <a href="https://github.com/peterdsp/Magnetio#disclaimer" target="_blank" rel="noreferrer">Read disclaimer</a>
-        </div>
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-orb hero-orb-1"></div>
+    <div class="hero-orb hero-orb-2"></div>
+    <div class="hero-orb hero-orb-3"></div>
+    <div class="hero-content">
+      <h1 class="hero-headline">
+        <span class="gradient-text">Stream anything.</span><br />Own your setup.
+      </h1>
+      <p class="hero-sub">
+        Magnetio is a self-hosted Stremio addon that aggregates torrents from 22+ providers,
+        resolves them through 8 debrid services, and delivers instant high-quality streams.
+      </p>
+      <div class="hero-buttons">
+        <a href="#configure" class="btn-hero-primary">Get Started</a>
+        <a href="https://github.com/peterdsp/Magnetio" target="_blank" rel="noreferrer" class="btn-hero-secondary">View on GitHub</a>
       </div>
     </div>
+  </section>
 
-    <div class="form-panel">
-      <section class="section">
-        <h2 class="section-title">Stream Rules</h2>
-        <div class="field-grid">
-          <label>
-            Sort order
-            <select id="sort">
-              <option value="qualityseeders">Quality then seeders</option>
-              <option value="qualitysize">Quality then size</option>
-              <option value="seeders">Seeders only</option>
-              <option value="size">Size only</option>
-            </select>
-          </label>
-          <label>
-            Max streams
-            <select id="limit">
-              <option value="5">5</option>
-              <option value="10">10</option>
-              <option value="20">20</option>
-              <option value="50">50</option>
-            </select>
-          </label>
-        </div>
-
-        <label>
-          Allowed qualities
-          <div class="chip-grid" id="qualities">
-            ${QUALITIES.map(([value, label]) => `<label class="chip"><input type="checkbox" value="${value}" /><span>${label}</span></label>`).join('')}
-          </div>
-        </label>
-
-        <label>
-          Audio languages
-          <div class="chip-grid" id="languages">
-            ${LANGUAGES.map(([value, label]) => `<label class="chip"><input type="checkbox" value="${value}" /><span>${label}</span></label>`).join('')}
-          </div>
-        </label>
-      </section>
-
-      <section class="section">
-        <h2 class="section-title">Subtitles</h2>
-        <p class="section-desc">Select every subtitle language you want returned. Magnetio provides a dedicated Stremio subtitles resource.</p>
-        <label>
-          Subtitle languages
-          <div class="chip-grid" id="subtitleLanguages">
-            ${LANGUAGES.map(([value, label]) => `<label class="chip"><input type="checkbox" value="${value}" /><span>${label}</span></label>`).join('')}
-          </div>
-        </label>
-      </section>
-
-      <section class="section">
-        <h2 class="section-title">Recommendations</h2>
-        <p class="section-desc">Enable "More Like This" suggestions powered by TMDB. Get a free API key at <a href="https://www.themoviedb.org/settings/api" target="_blank" rel="noreferrer" style="color:var(--accent)">themoviedb.org</a>.</p>
-        <div class="field-grid">
-          <label>
-            TMDB API Key
-            <div class="password-wrap">
-              <input type="password" id="tmdb" autocomplete="off" placeholder="TMDB API key (v3 auth)" />
-              <button type="button" class="eye-toggle" data-target="tmdb" title="Toggle visibility">${SVG_EYE}</button>
-            </div>
-          </label>
-        </div>
-      </section>
-
-      <section class="section">
-        <h2 class="section-title">Torznab / Jackett / Prowlarr</h2>
-        <p class="section-desc">Connect a Torznab-compatible indexer manager. Enter the full Torznab API URL and your API key.</p>
-        <div class="field-grid">
-          <label>
-            Torznab URL
-            <div class="password-wrap">
-              <input type="text" id="torznabUrl" autocomplete="off" placeholder="http://jackett:9117/api/v2.0/indexers/all/results/torznab" />
-            </div>
-          </label>
-          <label>
-            Torznab API Key
-            <div class="password-wrap">
-              <input type="password" id="torznabKey" autocomplete="off" placeholder="API key" />
-              <button type="button" class="eye-toggle" data-target="torznabKey" title="Toggle visibility">${SVG_EYE}</button>
-            </div>
-          </label>
-        </div>
-      </section>
-
-      <section class="section">
-        <h2 class="section-title">Debrid Services</h2>
-        <p class="section-desc">Add API keys for your debrid services. Cached torrents resolve as direct streams automatically.</p>
-        <div class="field-grid">
-          <label>
-            Debrid prewarm
-            <select id="prewarm">
-              <option value="1">Enabled</option>
-              <option value="0">Disabled</option>
-            </select>
-          </label>
-          <label>
-            Prewarm top uncached
-            <select id="prewarmLimit">
-              <option value="1">1</option>
-              <option value="2">2</option>
-              <option value="3">3</option>
-              <option value="5">5</option>
-            </select>
-          </label>
-        </div>
-        <div class="field-grid">
-          ${DEBRID_FIELDS.map(([id, label]) => `
-            <label>
-              ${label}
-              <div class="password-wrap">
-                <input type="password" id="${id}" autocomplete="off" placeholder="${label} API key" />
-                <button type="button" class="eye-toggle" data-target="${id}" title="Toggle visibility">${SVG_EYE}</button>
-              </div>
-            </label>
-          `).join('')}
-        </div>
-      </section>
+  <!-- Stats Bar -->
+  <div class="stats-bar">
+    <div class="stat-item">
+      <div class="stat-number">22+</div>
+      <div class="stat-label">Torrent Providers</div>
+    </div>
+    <div class="stat-item">
+      <div class="stat-number">8</div>
+      <div class="stat-label">Debrid Services</div>
+    </div>
+    <div class="stat-item">
+      <div class="stat-number">500+</div>
+      <div class="stat-label">Indexers via Torznab</div>
+    </div>
+    <div class="stat-item">
+      <div class="stat-number">24/7</div>
+      <div class="stat-label">Self-Hosted</div>
     </div>
   </div>
 
+  <!-- Features -->
+  <section class="page-section">
+    <div class="section-label">Features</div>
+    <h2 class="section-heading">Everything you need to stream</h2>
+    <p class="section-sub">Built for power users who want full control over their streaming pipeline.</p>
+    <div class="features-grid">
+      <div class="feature-card">
+        <span class="feature-icon">&#9889;</span>
+        <div class="feature-title">Multi-Provider Scraping</div>
+        <div class="feature-desc">22 torrent providers queried in parallel with smart deduplication and quality ranking.</div>
+      </div>
+      <div class="feature-card">
+        <span class="feature-icon">&#128279;</span>
+        <div class="feature-title">Debrid Integration</div>
+        <div class="feature-desc">8 debrid services for instant cached streams at full speed with automatic fallback.</div>
+      </div>
+      <div class="feature-card">
+        <span class="feature-icon">&#128270;</span>
+        <div class="feature-title">Torznab Support</div>
+        <div class="feature-desc">Connect Jackett or Prowlarr for 500+ additional indexers and private trackers.</div>
+      </div>
+      <div class="feature-card">
+        <span class="feature-icon">&#10024;</span>
+        <div class="feature-title">Smart Recommendations</div>
+        <div class="feature-desc">TMDB-powered similar content suggestions for every movie and series title.</div>
+      </div>
+      <div class="feature-card">
+        <span class="feature-icon">&#127916;</span>
+        <div class="feature-title">Subtitle Pipeline</div>
+        <div class="feature-desc">Automatic subtitle search, download, and sync with ffsubsync in 15 languages.</div>
+      </div>
+      <div class="feature-card">
+        <span class="feature-icon">&#128274;</span>
+        <div class="feature-title">Self-Hosted</div>
+        <div class="feature-desc">Runs on a Raspberry Pi. Your API keys never leave your server. No tracking, no telemetry.</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- How It Works -->
+  <section class="page-section">
+    <div class="section-label">How it works</div>
+    <h2 class="section-heading">Three steps to streaming</h2>
+    <p class="section-sub">From configuration to playback in under a minute.</p>
+    <div class="how-steps">
+      <div class="how-step">
+        <div class="how-step-number">1</div>
+        <div class="how-step-line"></div>
+        <div>
+          <div class="how-step-title">Configure</div>
+          <div class="how-step-desc">Set your quality preferences, debrid API keys, and optional Torznab indexers below.</div>
+        </div>
+      </div>
+      <div class="how-step">
+        <div class="how-step-number">2</div>
+        <div class="how-step-line"></div>
+        <div>
+          <div class="how-step-title">Install</div>
+          <div class="how-step-desc">One-click install into Stremio via the generated manifest URL. Works on any device.</div>
+        </div>
+      </div>
+      <div class="how-step">
+        <div class="how-step-number">3</div>
+        <div>
+          <div class="how-step-title">Stream</div>
+          <div class="how-step-desc">Play any movie or series with instant debrid-resolved streams at full quality.</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Configure -->
+  <div class="configure-section" id="configure">
+    <div class="section-label">Configure</div>
+    <h2 class="section-heading">Set up your addon</h2>
+    <p class="section-sub">Customize providers, quality filters, subtitles, and API keys.</p>
+
+    <div class="config-card">
+      <div class="config-card-title">Stream Rules</div>
+      <div class="field-grid">
+        <label>
+          Sort order
+          <select id="sort">
+            <option value="qualityseeders">Quality then seeders</option>
+            <option value="qualitysize">Quality then size</option>
+            <option value="seeders">Seeders only</option>
+            <option value="size">Size only</option>
+          </select>
+        </label>
+        <label>
+          Max streams
+          <select id="limit">
+            <option value="5">5</option>
+            <option value="10">10</option>
+            <option value="20">20</option>
+            <option value="50">50</option>
+          </select>
+        </label>
+      </div>
+
+      <label>
+        Allowed qualities
+        <div class="chip-grid" id="qualities">
+          ${QUALITIES.map(([value, label]) => `<label class="chip"><input type="checkbox" value="${value}" /><span>${label}</span></label>`).join('')}
+        </div>
+      </label>
+
+      <label>
+        Audio languages
+        <div class="chip-grid" id="languages">
+          ${LANGUAGES.map(([value, label]) => `<label class="chip"><input type="checkbox" value="${value}" /><span>${label}</span></label>`).join('')}
+        </div>
+      </label>
+    </div>
+
+    <div class="config-card">
+      <div class="config-card-title">Subtitles</div>
+      <div class="config-card-desc">Select every subtitle language you want returned. Magnetio provides a dedicated Stremio subtitles resource.</div>
+      <label>
+        Subtitle languages
+        <div class="chip-grid" id="subtitleLanguages">
+          ${LANGUAGES.map(([value, label]) => `<label class="chip"><input type="checkbox" value="${value}" /><span>${label}</span></label>`).join('')}
+        </div>
+      </label>
+    </div>
+
+    <div class="config-card">
+      <div class="config-card-title">Recommendations</div>
+      <div class="config-card-desc">Enable "More Like This" suggestions powered by TMDB. Get a free API key at <a href="https://www.themoviedb.org/settings/api" target="_blank" rel="noreferrer">themoviedb.org</a>.</div>
+      <div class="field-grid">
+        <label>
+          TMDB API Key
+          <div class="password-wrap">
+            <input type="password" id="tmdb" autocomplete="off" placeholder="TMDB API key (v3 auth)" />
+            <button type="button" class="eye-toggle" data-target="tmdb" title="Toggle visibility">${SVG_EYE}</button>
+          </div>
+        </label>
+      </div>
+    </div>
+
+    <div class="config-card">
+      <div class="config-card-title">Torznab / Jackett / Prowlarr</div>
+      <div class="config-card-desc">Connect a Torznab-compatible indexer manager. Enter the full Torznab API URL and your API key.</div>
+      <div class="field-grid">
+        <label>
+          Torznab URL
+          <div class="password-wrap">
+            <input type="text" id="torznabUrl" autocomplete="off" placeholder="http://jackett:9117/api/v2.0/indexers/all/results/torznab" />
+          </div>
+        </label>
+        <label>
+          Torznab API Key
+          <div class="password-wrap">
+            <input type="password" id="torznabKey" autocomplete="off" placeholder="API key" />
+            <button type="button" class="eye-toggle" data-target="torznabKey" title="Toggle visibility">${SVG_EYE}</button>
+          </div>
+        </label>
+      </div>
+    </div>
+
+    <div class="config-card">
+      <div class="config-card-title">Debrid Services</div>
+      <div class="config-card-desc">Add API keys for your debrid services. Cached torrents resolve as direct streams automatically.</div>
+      <div class="field-grid">
+        <label>
+          Debrid prewarm
+          <select id="prewarm">
+            <option value="1">Enabled</option>
+            <option value="0">Disabled</option>
+          </select>
+        </label>
+        <label>
+          Prewarm top uncached
+          <select id="prewarmLimit">
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="5">5</option>
+          </select>
+        </label>
+      </div>
+      <div class="field-grid">
+        ${DEBRID_FIELDS.map(([id, label]) => `
+          <label>
+            ${label}
+            <div class="password-wrap">
+              <input type="password" id="${id}" autocomplete="off" placeholder="${label} API key" />
+              <button type="button" class="eye-toggle" data-target="${id}" title="Toggle visibility">${SVG_EYE}</button>
+            </div>
+          </label>
+        `).join('')}
+      </div>
+    </div>
+  </div>
+
+  <!-- Install Bar (desktop) -->
+  <div class="install-bar" id="desktopSummary">
+    <div class="install-card">
+      <div class="install-card-label">Manifest URL</div>
+      <div class="install-card-url" id="manifestPreview"></div>
+      <div class="install-card-actions">
+        <button class="btn btn-primary" type="button" id="installBtn">Install in Stremio</button>
+        <button class="btn btn-secondary" type="button" id="copyBtn">Copy URL</button>
+      </div>
+      <div class="status" id="status"></div>
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer class="site-footer">
+    <div class="footer-text">
+      Magnetio does not host or distribute any content.
+      <a href="https://github.com/peterdsp/Magnetio#disclaimer" target="_blank" rel="noreferrer">Read disclaimer</a>.<br />
+      <a href="https://github.com/peterdsp/Magnetio" target="_blank" rel="noreferrer">GitHub</a>
+    </div>
+  </footer>
+
+  <!-- Mobile footer -->
   <div class="mobile-footer" id="mobileFooter">
     <div class="footer-actions">
       <button class="btn btn-primary" type="button" id="mobileInstallBtn">Install</button>
@@ -762,17 +1087,21 @@ export function landingTemplate(manifest, initialConfig = {}) {
 
     function updateThemeIcon() {
       const btn = document.getElementById('themeToggle');
+      if (!btn) return;
       const current = document.documentElement.getAttribute('data-theme');
       btn.innerHTML = current === 'dark' ? '${SVG_MOON}' : '${SVG_SUN}';
     }
 
-    document.getElementById('themeToggle').addEventListener('click', function() {
-      const current = document.documentElement.getAttribute('data-theme');
-      const next = current === 'dark' ? 'light' : 'dark';
-      document.documentElement.setAttribute('data-theme', next);
-      localStorage.setItem('magnetio-theme', next);
-      updateThemeIcon();
-    });
+    var themeBtn = document.getElementById('themeToggle');
+    if (themeBtn) {
+      themeBtn.addEventListener('click', function() {
+        const current = document.documentElement.getAttribute('data-theme');
+        const next = current === 'dark' ? 'light' : 'dark';
+        document.documentElement.setAttribute('data-theme', next);
+        localStorage.setItem('magnetio-theme', next);
+        updateThemeIcon();
+      });
+    }
 
     window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function(e) {
       if (!localStorage.getItem('magnetio-theme')) {
@@ -913,6 +1242,19 @@ export function landingTemplate(manifest, initialConfig = {}) {
         input.type = showing ? 'password' : 'text';
         this.innerHTML = showing ? '${SVG_EYE}' : '${SVG_EYE_OFF}';
       });
+    });
+
+    // Fade-in on scroll (IntersectionObserver)
+    document.querySelectorAll('.page-section').forEach(function(section) {
+      var observer = new IntersectionObserver(function(entries) {
+        entries.forEach(function(entry) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('visible');
+            observer.unobserve(entry.target);
+          }
+        });
+      }, { threshold: 0.1 });
+      observer.observe(section);
     });
 
     applyInitialState();

--- a/addon/lib/landingTemplate.js
+++ b/addon/lib/landingTemplate.js
@@ -58,6 +58,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
     subtitleLanguages: initialConfig.subtitleLanguages ?? ['en'],
     prewarmDebrid: initialConfig.prewarmDebrid ?? true,
     prewarmLimit: initialConfig.prewarmLimit ?? 3,
+    tmdbApiKey: initialConfig.tmdbApiKey ?? '',
     torznabUrl: initialConfig.torznabUrl ?? '',
     torznabApiKey: initialConfig.torznabApiKey ?? '',
     realDebridApiKey: initialConfig.realDebridApiKey ?? '',
@@ -669,6 +670,20 @@ export function landingTemplate(manifest, initialConfig = {}) {
       </section>
 
       <section class="section">
+        <h2 class="section-title">Recommendations</h2>
+        <p class="section-desc">Enable "More Like This" suggestions powered by TMDB. Get a free API key at <a href="https://www.themoviedb.org/settings/api" target="_blank" rel="noreferrer" style="color:var(--accent)">themoviedb.org</a>.</p>
+        <div class="field-grid">
+          <label>
+            TMDB API Key
+            <div class="password-wrap">
+              <input type="password" id="tmdb" autocomplete="off" placeholder="TMDB API key (v3 auth)" />
+              <button type="button" class="eye-toggle" data-target="tmdb" title="Toggle visibility">${SVG_EYE}</button>
+            </div>
+          </label>
+        </div>
+      </section>
+
+      <section class="section">
         <h2 class="section-title">Torznab / Jackett / Prowlarr</h2>
         <p class="section-desc">Connect a Torznab-compatible indexer manager. Enter the full Torznab API URL and your API key.</p>
         <div class="field-grid">
@@ -799,6 +814,8 @@ export function landingTemplate(manifest, initialConfig = {}) {
       setChipGrid('languages', initialConfig.languages || []);
       setChipGrid('subtitleLanguages', initialConfig.subtitleLanguages || ['en']);
 
+      document.getElementById('tmdb').value = initialConfig.tmdbApiKey || '';
+
       document.getElementById('torznabUrl').value = initialConfig.torznabUrl || '';
       document.getElementById('torznabKey').value = initialConfig.torznabApiKey || '';
 
@@ -826,6 +843,9 @@ export function landingTemplate(manifest, initialConfig = {}) {
       if (qualities.length) parts.push('qualities=' + qualities.join(','));
       if (languages.length) parts.push('languages=' + languages.join(','));
       if (subtitleLanguages.length) parts.push('subtitleLanguages=' + subtitleLanguages.join(','));
+
+      var tmdbKey = document.getElementById('tmdb').value.trim();
+      if (tmdbKey) parts.push('tmdb=' + tmdbKey);
 
       var torznabUrl = document.getElementById('torznabUrl').value.trim();
       var torznabKey = document.getElementById('torznabKey').value.trim();

--- a/addon/lib/landingTemplate.js
+++ b/addon/lib/landingTemplate.js
@@ -58,6 +58,8 @@ export function landingTemplate(manifest, initialConfig = {}) {
     subtitleLanguages: initialConfig.subtitleLanguages ?? ['en'],
     prewarmDebrid: initialConfig.prewarmDebrid ?? true,
     prewarmLimit: initialConfig.prewarmLimit ?? 3,
+    torznabUrl: initialConfig.torznabUrl ?? '',
+    torznabApiKey: initialConfig.torznabApiKey ?? '',
     realDebridApiKey: initialConfig.realDebridApiKey ?? '',
     premiumizeApiKey: initialConfig.premiumizeApiKey ?? '',
     allDebridApiKey: initialConfig.allDebridApiKey ?? '',
@@ -564,6 +566,24 @@ export function landingTemplate(manifest, initialConfig = {}) {
       </section>
 
       <section class="card section">
+        <h2 class="section-title">Torznab / Jackett / Prowlarr</h2>
+        <p class="section-desc">Connect a Torznab-compatible indexer manager. Enter the full Torznab API URL and your API key.</p>
+        <div class="field-grid">
+          <label>
+            Torznab URL
+            <input type="text" id="torznabUrl" autocomplete="off" placeholder="http://jackett:9117/api/v2.0/indexers/all/results/torznab" />
+          </label>
+          <label>
+            Torznab API Key
+            <div class="password-wrap">
+              <input type="password" id="torznabKey" autocomplete="off" placeholder="API key" />
+              <button type="button" class="eye-toggle" data-target="torznabKey" title="Toggle visibility">${SVG_EYE}</button>
+            </div>
+          </label>
+        </div>
+      </section>
+
+      <section class="card section">
         <h2 class="section-title">Debrid Services</h2>
         <p class="section-desc">Add API keys for your debrid services. Cached torrents resolve as direct streams automatically.</p>
         <div class="field-grid">
@@ -697,6 +717,9 @@ export function landingTemplate(manifest, initialConfig = {}) {
       setChipGrid('languages', initialConfig.languages || []);
       setChipGrid('subtitleLanguages', initialConfig.subtitleLanguages || ['en']);
 
+      document.getElementById('torznabUrl').value = initialConfig.torznabUrl || '';
+      document.getElementById('torznabKey').value = initialConfig.torznabApiKey || '';
+
       document.getElementById('rd').value = initialConfig.realDebridApiKey || '';
       document.getElementById('pm').value = initialConfig.premiumizeApiKey || '';
       document.getElementById('ad').value = initialConfig.allDebridApiKey || '';
@@ -721,6 +744,11 @@ export function landingTemplate(manifest, initialConfig = {}) {
       if (qualities.length) parts.push('qualities=' + qualities.join(','));
       if (languages.length) parts.push('languages=' + languages.join(','));
       if (subtitleLanguages.length) parts.push('subtitleLanguages=' + subtitleLanguages.join(','));
+
+      var torznabUrl = document.getElementById('torznabUrl').value.trim();
+      var torznabKey = document.getElementById('torznabKey').value.trim();
+      if (torznabUrl) parts.push('torznabUrl=' + encodeURIComponent(torznabUrl));
+      if (torznabKey) parts.push('torznabKey=' + torznabKey);
 
       var keys = ['rd','pm','ad','dl','ed','oc','tb','pu'];
       keys.forEach(function(id) {

--- a/addon/lib/landingTemplate.js
+++ b/addon/lib/landingTemplate.js
@@ -1236,7 +1236,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
       var torznabUrl = document.getElementById('torznabUrl').value.trim();
       var torznabKey = document.getElementById('torznabKey').value.trim();
       if (torznabUrl) parts.push('torznabUrl=' + encodeURIComponent(torznabUrl));
-      if (torznabKey) parts.push('torznabKey=' + torznabKey);
+      if (torznabKey) parts.push('torznabKey=' + encodeURIComponent(torznabKey));
 
       var keys = ['rd','pm','ad','dl','ed','oc','tb','pu'];
       keys.forEach(function(id) {

--- a/addon/lib/landingTemplate.js
+++ b/addon/lib/landingTemplate.js
@@ -213,6 +213,12 @@ export function landingTemplate(manifest, initialConfig = {}) {
       letter-spacing: -0.03em;
     }
 
+    .hero-headline em {
+      font-style: italic;
+      font-weight: 400;
+      color: var(--text-muted);
+    }
+
     .hero-desc {
       font-family: "Space Mono", monospace;
       font-size: 0.85rem;
@@ -223,32 +229,44 @@ export function landingTemplate(manifest, initialConfig = {}) {
 
     .hero-features {
       display: grid;
-      grid-template-columns: 1fr 1fr 1fr;
-      gap: 12px;
+      grid-template-columns: 1fr 1fr;
+      gap: 0;
       margin-top: 8px;
+      border-radius: 16px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      backdrop-filter: blur(6px);
+      overflow: hidden;
     }
 
     .feature {
-      padding: 16px;
-      border-radius: 12px;
-      background: var(--surface);
-      border: 1px solid var(--border);
+      padding: 16px 20px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .feature:nth-child(odd) {
+      border-right: 1px solid var(--border);
+    }
+
+    .feature:nth-last-child(-n+2) {
+      border-bottom: none;
     }
 
     .feature-number {
       font-family: "Bitter", serif;
       font-weight: 800;
-      font-size: 2rem;
-      color: var(--text-muted);
+      font-size: 1.6rem;
+      color: var(--text-primary);
       line-height: 1;
     }
 
     .feature-label {
-      font-family: "Bitter", serif;
-      font-weight: 500;
-      font-size: 0.78rem;
+      font-family: "Space Mono", monospace;
+      font-weight: 400;
+      font-size: 0.7rem;
       color: var(--text-secondary);
-      margin-top: 4px;
+      margin-top: 6px;
+      line-height: 1.4;
     }
 
     .hero-bottom { display: grid; gap: 16px; }
@@ -522,7 +540,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
         border-bottom: 1px solid var(--border);
       }
       .hero-headline { font-size: 2rem; }
-      .hero-features { grid-template-columns: 1fr 1fr 1fr; }
+      .hero-features { grid-template-columns: 1fr 1fr; }
       .hero-install { display: none; }
       .mobile-footer { display: block; }
       body { padding-bottom: 90px; }
@@ -533,9 +551,9 @@ export function landingTemplate(manifest, initialConfig = {}) {
       .hero-panel { padding: 24px 20px; }
       .hero-headline { font-size: 1.6rem; }
       .hero-desc { font-size: 0.78rem; }
-      .hero-features { grid-template-columns: 1fr; gap: 8px; }
-      .feature { padding: 12px; display: flex; align-items: center; gap: 12px; }
-      .feature-number { font-size: 1.4rem; }
+      .hero-features { grid-template-columns: 1fr 1fr; }
+      .feature { padding: 12px 16px; }
+      .feature-number { font-size: 1.2rem; }
       .form-panel { padding: 16px 12px; }
       .section { padding: 20px; }
       .field-grid { grid-template-columns: 1fr; }
@@ -559,22 +577,26 @@ export function landingTemplate(manifest, initialConfig = {}) {
         </div>
 
         <div>
-          <h1 class="hero-headline">Stream everything, your way</h1>
+          <h1 class="hero-headline">Stream <em>your</em> own way</h1>
           <p class="hero-desc">Configure providers, debrid services and subtitles. Install the result in Stremio with one click.</p>
         </div>
 
         <div class="hero-features">
           <div class="feature">
-            <div class="feature-number">01</div>
-            <div class="feature-label">Torznab indexers</div>
+            <div class="feature-number">8+</div>
+            <div class="feature-label">Debrid services supported</div>
           </div>
           <div class="feature">
-            <div class="feature-number">02</div>
-            <div class="feature-label">Debrid services</div>
+            <div class="feature-number">15</div>
+            <div class="feature-label">Subtitle languages</div>
           </div>
           <div class="feature">
-            <div class="feature-number">03</div>
-            <div class="feature-label">Subtitle sync</div>
+            <div class="feature-number">5</div>
+            <div class="feature-label">Quality tiers</div>
+          </div>
+          <div class="feature">
+            <div class="feature-number">1-click</div>
+            <div class="feature-label">Stremio install</div>
           </div>
         </div>
       </div>

--- a/addon/lib/landingTemplate.js
+++ b/addon/lib/landingTemplate.js
@@ -548,7 +548,6 @@ export function landingTemplate(manifest, initialConfig = {}) {
       <div class="hero-top">
         <div class="hero-brand">
           <div class="hero-brand-left">
-            <img class="hero-logo" src="${escapeHtml(manifest.logo)}" alt="" />
             <span class="hero-name">${escapeHtml(manifest.name)}</span>
           </div>
           <div style="display:flex;align-items:center;gap:10px;">

--- a/addon/lib/landingTemplate.js
+++ b/addon/lib/landingTemplate.js
@@ -76,7 +76,64 @@ export function landingTemplate(manifest, initialConfig = {}) {
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>${escapeHtml(manifest.name)} - Stream Anything</title>
+  <title>${escapeHtml(manifest.name)} - Self-Hosted Stremio Addon with 22+ Providers and Debrid Support</title>
+  <meta name="description" content="Magnetio is a free, open-source, self-hosted Stremio addon with 22+ torrent providers, 8 debrid services, Torznab/Jackett/Prowlarr support, TMDB recommendations, and subtitle sync. Stream movies, series, and anime instantly." />
+  <meta name="keywords" content="Magnetio, Stremio addon, self-hosted, torrent, debrid, Real-Debrid, Premiumize, AllDebrid, TorBox, Jackett, Prowlarr, Torznab, streaming, movies, series, anime, open source, TMDB" />
+  <meta name="author" content="peterdsp" />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://magnetio.peterdsp.dev/" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Magnetio - Self-Hosted Stremio Addon" />
+  <meta property="og:description" content="Stream anything with 22+ providers, 8 debrid services, Torznab support, and TMDB recommendations. Fully self-hosted, your API keys never leave your server." />
+  <meta property="og:url" content="https://magnetio.peterdsp.dev/" />
+  <meta property="og:site_name" content="Magnetio" />
+  <meta property="og:image" content="https://magnetio.peterdsp.dev/og-image.png" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Magnetio - Self-Hosted Stremio Addon" />
+  <meta name="twitter:description" content="Stream anything with 22+ providers, 8 debrid services, and Torznab support. Open source and self-hosted." />
+  <meta name="twitter:image" content="https://magnetio.peterdsp.dev/og-image.png" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Magnetio",
+    "applicationCategory": "MultimediaApplication",
+    "operatingSystem": "Docker, Node.js",
+    "url": "https://magnetio.peterdsp.dev",
+    "description": "Self-hosted Stremio addon with 22+ torrent providers, 8 debrid services, Torznab/Jackett/Prowlarr support, TMDB recommendations, and subtitle sync pipeline.",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "author": {
+      "@type": "Person",
+      "name": "peterdsp",
+      "url": "https://github.com/peterdsp"
+    },
+    "softwareVersion": "${escapeHtml(manifest.version)}",
+    "license": "https://github.com/peterdsp/Magnetio/blob/main/LICENSE",
+    "codeRepository": "https://github.com/peterdsp/Magnetio",
+    "featureList": [
+      "22+ torrent providers",
+      "8 debrid services (Real-Debrid, Premiumize, AllDebrid, TorBox, etc.)",
+      "Torznab/Jackett/Prowlarr integration",
+      "TMDB similar content recommendations",
+      "Subtitle search and sync pipeline",
+      "Background cache prewarm",
+      "Self-hosted on Raspberry Pi or any server"
+    ]
+  }
+  </script>
+
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />

--- a/addon/lib/landingTemplate.js
+++ b/addon/lib/landingTemplate.js
@@ -571,7 +571,9 @@ export function landingTemplate(manifest, initialConfig = {}) {
         <div class="field-grid">
           <label>
             Torznab URL
-            <input type="text" id="torznabUrl" autocomplete="off" placeholder="http://jackett:9117/api/v2.0/indexers/all/results/torznab" />
+            <div class="password-wrap">
+              <input type="text" id="torznabUrl" autocomplete="off" placeholder="http://jackett:9117/api/v2.0/indexers/all/results/torznab" />
+            </div>
           </label>
           <label>
             Torznab API Key

--- a/addon/lib/manifest.js
+++ b/addon/lib/manifest.js
@@ -72,7 +72,7 @@ function getDescription(config) {
 }
 
 function getCatalogs(config) {
-  return getEnabledMochs(config).flatMap(moch =>
+  const debridCatalogs = getEnabledMochs(config).flatMap(moch =>
     moch.hasCatalog
       ? [
           { id: `${moch.id}_movie`,  type: 'movie',  name: `${moch.name} - Movies`  },
@@ -80,6 +80,25 @@ function getCatalogs(config) {
         ]
       : []
   );
+
+  const similarCatalogs = config?.tmdbApiKey
+    ? [
+        {
+          id: 'magnetio_similar_movie',
+          type: 'movie',
+          name: 'Magnetio - Similar',
+          extra: [{ name: 'genre', isRequired: true }],
+        },
+        {
+          id: 'magnetio_similar_series',
+          type: 'series',
+          name: 'Magnetio - Similar',
+          extra: [{ name: 'genre', isRequired: true }],
+        },
+      ]
+    : [];
+
+  return [...debridCatalogs, ...similarCatalogs];
 }
 
 function getResources() {
@@ -97,7 +116,7 @@ function getResources() {
     {
       name: 'catalog',
       types: ['movie', 'series'],
-      idPrefixes: ['rd', 'pm', 'ad', 'dl', 'ed', 'oc', 'tb', 'pu'],
+      idPrefixes: ['rd', 'pm', 'ad', 'dl', 'ed', 'oc', 'tb', 'pu', 'magnetio_similar'],
     },
     {
       name: 'meta',

--- a/addon/lib/repository.js
+++ b/addon/lib/repository.js
@@ -5,6 +5,14 @@ import { logger } from './logger.js';
 const SCRAPER_BASE_URL = process.env.SCRAPER_URL || 'http://localhost:8080';
 const REQUEST_TIMEOUT  = 30_000;
 
+function simpleHash(str) {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = ((h << 5) - h + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h).toString(36);
+}
+
 /**
  * Fetch torrent stream records from the scraper back-end.
  *
@@ -18,13 +26,22 @@ const REQUEST_TIMEOUT  = 30_000;
  */
 export async function getStreams(type, id, config) {
   const providerKey = config?.providers?.length ? config.providers.join(',') : 'all';
-  const cacheKey = `streams:${type}:${id}:${providerKey}`;
+  const torznabSuffix = config.torznabUrl
+    ? `:tz-${simpleHash(config.torznabUrl)}`
+    : '';
+  const cacheKey = `streams:${type}:${id}:${providerKey}${torznabSuffix}`;
 
   return cacheWrap(cacheKey, async () => {
     try {
+      const params = { providers: config.providers?.join(',') };
+      if (config.torznabUrl) {
+        params.torznabUrl = config.torznabUrl;
+        params.torznabApiKey = config.torznabApiKey || '';
+      }
+
       const { data } = await axios.get(`${SCRAPER_BASE_URL}/streams/${type}/${id}`, {
         timeout: REQUEST_TIMEOUT,
-        params:  { providers: config.providers?.join(',') },
+        params,
       });
       return Array.isArray(data.streams) ? data.streams : [];
     } catch (err) {

--- a/addon/lib/repository.js
+++ b/addon/lib/repository.js
@@ -27,7 +27,7 @@ function simpleHash(str) {
 export async function getStreams(type, id, config) {
   const providerKey = config?.providers?.length ? config.providers.join(',') : 'all';
   const torznabSuffix = config.torznabUrl
-    ? `:tz-${simpleHash(config.torznabUrl)}`
+    ? `:tz-${simpleHash(config.torznabUrl + (config.torznabApiKey || ''))}`
     : '';
   const cacheKey = `streams:${type}:${id}:${providerKey}${torznabSuffix}`;
 

--- a/addon/lib/requestContext.js
+++ b/addon/lib/requestContext.js
@@ -1,0 +1,18 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const storage = new AsyncLocalStorage();
+
+/**
+ * Run a callback within a request context that carries the client IP.
+ */
+export function runWithClientIp(ip, fn) {
+  return storage.run({ clientIp: ip }, fn);
+}
+
+/**
+ * Retrieve the client IP from the current async context.
+ * Returns undefined if called outside a request context.
+ */
+export function getClientIp() {
+  return storage.getStore()?.clientIp;
+}

--- a/addon/lib/similar.js
+++ b/addon/lib/similar.js
@@ -1,0 +1,157 @@
+/**
+ * Similar content recommendations via TMDB API.
+ *
+ * Converts IMDb IDs to TMDB IDs, fetches recommendations,
+ * and returns Stremio-compatible meta objects.
+ */
+import axios from 'axios';
+import { cacheWrap } from './cache.js';
+import { logger } from './logger.js';
+
+const TMDB_BASE = 'https://api.themoviedb.org/3';
+const POSTER_BASE = 'https://image.tmdb.org/t/p/w500';
+const BACKDROP_BASE = 'https://image.tmdb.org/t/p/w780';
+
+const CACHE_TTL_ID_MAP = 604800;    // 7 days for IMDb-to-TMDB mapping
+const CACHE_TTL_RECS   = 86400;     // 24 hours for recommendations
+const REQUEST_TIMEOUT  = 8000;
+
+/**
+ * Get similar content recommendations for a given IMDb ID.
+ *
+ * @param {string} imdbId    IMDb ID (e.g. 'tt1234567')
+ * @param {string} type      'movie' or 'series'
+ * @param {string} apiKey    TMDB API key
+ * @returns {Promise<StremioMeta[]>}
+ */
+export async function getSimilarContent(imdbId, type, apiKey) {
+  if (!apiKey || !imdbId) return [];
+
+  const cacheKey = `similar:${type}:${imdbId}`;
+
+  return cacheWrap(cacheKey, async () => {
+    try {
+      const tmdbId = await imdbToTmdb(imdbId, type, apiKey);
+      if (!tmdbId) {
+        logger.warn(`[Similar] No TMDB ID found for ${imdbId}`);
+        return [];
+      }
+
+      const recs = await fetchRecommendations(tmdbId, type, apiKey);
+      const metas = await Promise.all(
+        recs.map(r => enrichWithImdb(r, type, apiKey))
+      );
+
+      const valid = metas.filter(m => m && m.id);
+      logger.info(`[Similar] ${valid.length} recommendations for ${imdbId}`);
+      return valid;
+    } catch (err) {
+      logger.warn(`[Similar] ${err.message}`);
+      return [];
+    }
+  }, CACHE_TTL_RECS);
+}
+
+/**
+ * Convert an IMDb ID to a TMDB ID using the /find endpoint.
+ */
+async function imdbToTmdb(imdbId, type, apiKey) {
+  const cacheKey = `tmdb-id:${imdbId}`;
+
+  return cacheWrap(cacheKey, async () => {
+    const { data } = await axios.get(`${TMDB_BASE}/find/${imdbId}`, {
+      timeout: REQUEST_TIMEOUT,
+      params: { api_key: apiKey, external_source: 'imdb_id' },
+    });
+
+    if (type === 'series' || type === 'anime') {
+      const tv = data.tv_results?.[0];
+      return tv?.id || null;
+    }
+
+    const movie = data.movie_results?.[0];
+    return movie?.id || null;
+  }, CACHE_TTL_ID_MAP);
+}
+
+/**
+ * Fetch recommendations from TMDB for a given TMDB ID.
+ */
+async function fetchRecommendations(tmdbId, type, apiKey) {
+  const endpoint = (type === 'series' || type === 'anime') ? 'tv' : 'movie';
+
+  const { data } = await axios.get(
+    `${TMDB_BASE}/${endpoint}/${tmdbId}/recommendations`,
+    {
+      timeout: REQUEST_TIMEOUT,
+      params: { api_key: apiKey, page: 1 },
+    }
+  );
+
+  return data.results || [];
+}
+
+/**
+ * Enrich a TMDB result with its IMDb ID and convert to Stremio meta format.
+ */
+async function enrichWithImdb(tmdbResult, type, apiKey) {
+  const endpoint = (type === 'series' || type === 'anime') ? 'tv' : 'movie';
+  const tmdbId = tmdbResult.id;
+
+  try {
+    const cacheKey = `tmdb-external:${endpoint}:${tmdbId}`;
+    const imdbId = await cacheWrap(cacheKey, async () => {
+      const { data } = await axios.get(
+        `${TMDB_BASE}/${endpoint}/${tmdbId}/external_ids`,
+        { timeout: REQUEST_TIMEOUT, params: { api_key: apiKey } }
+      );
+      return data.imdb_id || null;
+    }, CACHE_TTL_ID_MAP);
+
+    if (!imdbId) return null;
+
+    return toStremioMeta(tmdbResult, type, imdbId);
+  } catch {
+    return toStremioMeta(tmdbResult, type, null);
+  }
+}
+
+/**
+ * Convert a TMDB result object to a Stremio meta preview.
+ */
+function toStremioMeta(item, type, imdbId) {
+  const title = item.title || item.name || '';
+  const releaseDate = item.release_date || item.first_air_date || '';
+  const year = releaseDate ? releaseDate.substring(0, 4) : '';
+  const rating = item.vote_average ? String(Math.round(item.vote_average * 10) / 10) : '';
+
+  if (!imdbId) return null;
+
+  const meta = {
+    id: imdbId,
+    type: (type === 'anime') ? 'series' : type,
+    name: title,
+  };
+
+  if (item.poster_path) {
+    meta.poster = `${POSTER_BASE}${item.poster_path}`;
+  }
+
+  if (item.backdrop_path) {
+    meta.background = `${BACKDROP_BASE}${item.backdrop_path}`;
+  }
+
+  if (item.overview) {
+    meta.description = item.overview;
+  }
+
+  if (year) {
+    meta.releaseInfo = year;
+  }
+
+  if (rating) {
+    meta.imdbRating = rating;
+  }
+
+  return meta;
+}

--- a/addon/lib/types.js
+++ b/addon/lib/types.js
@@ -24,6 +24,7 @@ export const TorrentProvider = {
   GLOTORRENTS: 'glotorrents',
   TORLOCK: 'torlock',
   TORRENTDOWNLOADS: 'torrentdownloads',
+  TORZNAB: 'torznab',
 };
 
 // Sort options exposed in configuration

--- a/addon/moch/realdebrid.js
+++ b/addon/moch/realdebrid.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { isValidToken, blacklistToken, selectVideoFile, buildDebridStream, resolveWithCache } from './mochHelper.js';
 import { logger } from '../lib/logger.js';
+import { getClientIp } from '../lib/requestContext.js';
 
 const RD_BASE = 'https://api.real-debrid.com/rest/1.0';
 const SERVICE  = 'RD';
@@ -202,6 +203,10 @@ function rdGet(url, apiKey, params = {}) {
 }
 
 function rdPost(url, apiKey, data = {}) {
+  const clientIp = getClientIp();
+  if (clientIp) {
+    data.ip = clientIp;
+  }
   const form = new URLSearchParams(data);
   return axios.post(url, form.toString(), {
     headers: {

--- a/addon/serverless.js
+++ b/addon/serverless.js
@@ -9,6 +9,7 @@ import { landingTemplate } from './lib/landingTemplate.js';
 import { logger } from './lib/logger.js';
 import { handleSubtitleProxyRequest } from './lib/subtitleProxy.js';
 import { trackRequest, getStats } from './lib/analytics.js';
+import { runWithClientIp } from './lib/requestContext.js';
 
 const router = express.Router();
 const ROUTER_CACHE_TTL_MS = 1000 * 60 * 5;
@@ -72,21 +73,25 @@ router.get('/:configuration/configure', (req, res) => {
 });
 
 router.use('/:configuration', async (req, res, next) => {
-  try {
-    const configHash = hashConfiguration(req.params.configuration);
-    const pathAfterConfig = req.path.replace(/^\/[^/]+/, '');
-    const type = pathAfterConfig.match(/^\/(stream|catalog|subtitle|meta)\b/)?.[1] || 'page';
-    trackRequest(type, configHash).catch(() => {});
+  const clientIp = req.ip || req.connection?.remoteAddress;
 
-    const addonRouter = await getConfiguredAddonRouter(
-      req.params.configuration,
-      getPublicBaseUrl(req),
-    );
-    addonRouter(req, res, next);
-  } catch (err) {
-    logger.error(`Addon routing error: ${err.message}`);
-    res.status(500).json({ error: err.message });
-  }
+  runWithClientIp(clientIp, async () => {
+    try {
+      const configHash = hashConfiguration(req.params.configuration);
+      const pathAfterConfig = req.path.replace(/^\/[^/]+/, '');
+      const type = pathAfterConfig.match(/^\/(stream|catalog|subtitle|meta)\b/)?.[1] || 'page';
+      trackRequest(type, configHash).catch(() => {});
+
+      const addonRouter = await getConfiguredAddonRouter(
+        req.params.configuration,
+        getPublicBaseUrl(req),
+      );
+      addonRouter(req, res, next);
+    } catch (err) {
+      logger.error(`Addon routing error: ${err.message}`);
+      res.status(500).json({ error: err.message });
+    }
+  });
 });
 
 export const serverless = router;

--- a/addon/serverless.js
+++ b/addon/serverless.js
@@ -31,6 +31,41 @@ router.get('/manifest.json', (_req, res) => {
   res.json(dummyManifest());
 });
 
+// ─── SEO: robots.txt and sitemap ─────────────────────────────────────────────
+
+router.get('/robots.txt', (_req, res) => {
+  res.type('text/plain').send([
+    'User-agent: *',
+    'Allow: /',
+    'Disallow: /proxy/',
+    'Disallow: /swagger',
+    'Disallow: /stats',
+    '',
+    'Sitemap: https://magnetio.peterdsp.dev/sitemap.xml',
+  ].join('\n'));
+});
+
+router.get('/sitemap.xml', (_req, res) => {
+  const now = new Date().toISOString().split('T')[0];
+  res.type('application/xml').send([
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    '  <url>',
+    '    <loc>https://magnetio.peterdsp.dev/</loc>',
+    `    <lastmod>${now}</lastmod>`,
+    '    <changefreq>weekly</changefreq>',
+    '    <priority>1.0</priority>',
+    '  </url>',
+    '  <url>',
+    '    <loc>https://magnetio.peterdsp.dev/configure</loc>',
+    `    <lastmod>${now}</lastmod>`,
+    '    <changefreq>weekly</changefreq>',
+    '    <priority>0.8</priority>',
+    '  </url>',
+    '</urlset>',
+  ].join('\n'));
+});
+
 const subtitleProxyLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   max: 100,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,8 +86,49 @@ services:
       timeout: 5s
       retries: 5
 
+  # ─── Jackett (Optional) ───────────────────────────────────────────────────
+  jackett:
+    image: lscr.io/linuxserver/jackett:latest
+    container_name: magnetio_jackett
+    restart: unless-stopped
+    profiles:
+      - jackett
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=${TZ:-Etc/UTC}
+      - AUTO_UPDATE=true
+    volumes:
+      - jackett_config:/config
+      - jackett_downloads:/downloads
+    ports:
+      - "${JACKETT_PORT:-9117}:9117"
+    networks:
+      - magnetio_net
+
+  # ─── Prowlarr (Optional) ─────────────────────────────────────────────────
+  prowlarr:
+    image: lscr.io/linuxserver/prowlarr:latest
+    container_name: magnetio_prowlarr
+    restart: unless-stopped
+    profiles:
+      - prowlarr
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=${TZ:-Etc/UTC}
+    volumes:
+      - prowlarr_config:/config
+    ports:
+      - "${PROWLARR_PORT:-9696}:9696"
+    networks:
+      - magnetio_net
+
 volumes:
   redis_data:
+  jackett_config:
+  jackett_downloads:
+  prowlarr_config:
 
 networks:
   magnetio_net:

--- a/scraper/index.js
+++ b/scraper/index.js
@@ -55,7 +55,7 @@ app.get('/streams/:type/:id', async (req, res) => {
   }
 
   const torznabSuffix = torznabUrl
-    ? `:tz-${crypto.createHash('sha256').update(torznabUrl).digest('hex').slice(0, 12)}`
+    ? `:tz-${crypto.createHash('sha256').update(torznabUrl + (torznabApiKey || '')).digest('hex').slice(0, 12)}`
     : '';
   const cacheKey = `streams:${type}:${id}:${providerIds?.join(',') ?? 'all'}${torznabSuffix}`;
 

--- a/scraper/index.js
+++ b/scraper/index.js
@@ -1,4 +1,5 @@
 import 'dotenv/config';
+import crypto from 'crypto';
 import express from 'express';
 import { scrapeAll, listProviders } from './providers/index.js';
 import { getMetadata } from './lib/cinemeta.js';
@@ -45,11 +46,18 @@ app.get('/streams/:type/:id', async (req, res) => {
     ? req.query.providers.split(',').map(s => s.trim()).filter(Boolean)
     : null;
 
+  const torznabUrl    = req.query.torznabUrl || null;
+  const torznabApiKey = req.query.torznabApiKey || null;
+  const context = { torznabUrl, torznabApiKey };
+
   if (!['movie', 'series', 'anime'].includes(type)) {
     return res.status(400).json({ error: 'Invalid type. Use movie, series, or anime.' });
   }
 
-  const cacheKey = `streams:${type}:${id}:${providerIds?.join(',') ?? 'all'}`;
+  const torznabSuffix = torznabUrl
+    ? `:tz-${crypto.createHash('sha256').update(torznabUrl).digest('hex').slice(0, 12)}`
+    : '';
+  const cacheKey = `streams:${type}:${id}:${providerIds?.join(',') ?? 'all'}${torznabSuffix}`;
 
   try {
     const { value: streams, cached } = await cacheWrap(cacheKey, async () => {
@@ -64,7 +72,7 @@ app.get('/streams/:type/:id', async (req, res) => {
       logger.info(`Scraping ${label} [${type}] from ${providerIds?.join(',') ?? 'all providers'}`);
 
       // 2. Scrape all providers in parallel
-      return scrapeAll(type, meta, providerIds);
+      return scrapeAll(type, meta, providerIds, context);
     }, TTL_STREAMS);
 
     res.json({ streams, cached });

--- a/scraper/providers/index.js
+++ b/scraper/providers/index.js
@@ -62,6 +62,7 @@ const PROVIDER_TIMEOUT_MS = 22_000;
  * @param {string}   type        'movie' | 'series' | 'anime'
  * @param {object}   meta        From cinemeta: { name, year, imdbId, season, episode }
  * @param {string[]} providerIds Optional whitelist of provider IDs
+ * @param {object}   context     Optional per-request context (e.g. { torznabUrl, torznabApiKey })
  * @returns {Promise<TorrentRecord[]>}
  */
 export async function scrapeAll(type, meta, providerIds = null, context = {}) {

--- a/scraper/providers/index.js
+++ b/scraper/providers/index.js
@@ -24,6 +24,7 @@ import * as therarbg         from './therarbg.js';
 import * as subsplease       from './subsplease.js';
 import * as animetosho       from './animetosho.js';
 import * as nekobt           from './nekobt.js';
+import * as torznab          from './torznab.js';
 import { logger } from '../lib/logger.js';
 
 const ALL_PROVIDERS = [
@@ -48,6 +49,7 @@ const ALL_PROVIDERS = [
   subsplease,
   animetosho,
   nekobt,
+  torznab,
 ];
 
 // Max 4 providers running simultaneously
@@ -62,7 +64,7 @@ const PROVIDER_TIMEOUT_MS = 22_000;
  * @param {string[]} providerIds Optional whitelist of provider IDs
  * @returns {Promise<TorrentRecord[]>}
  */
-export async function scrapeAll(type, meta, providerIds = null) {
+export async function scrapeAll(type, meta, providerIds = null, context = {}) {
   const providers = ALL_PROVIDERS.filter(p =>
     !providerIds || providerIds.includes(p.id)
   );
@@ -72,7 +74,7 @@ export async function scrapeAll(type, meta, providerIds = null) {
       limit(async () => {
         const start   = Date.now();
         const results = await withTimeout(
-          p.scrape({ ...meta, type }),
+          p.scrape({ ...meta, ...context, type }),
           PROVIDER_TIMEOUT_MS,
           `${p.name} timed out`
         );

--- a/scraper/providers/torznab.js
+++ b/scraper/providers/torznab.js
@@ -19,6 +19,17 @@ export async function scrape(meta) {
   if (!baseUrl) return [];
 
   try {
+    const parsed = new URL(baseUrl);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      logger.warn('[Torznab] Rejected non-HTTP URL scheme');
+      return [];
+    }
+  } catch {
+    logger.warn('[Torznab] Invalid URL provided');
+    return [];
+  }
+
+  try {
     const params = buildParams(meta, apiKey);
 
     const { data } = await get(baseUrl, {
@@ -36,7 +47,8 @@ export async function scrape(meta) {
       if (record) results.push(record);
     });
 
-    logger.info(`[Torznab] ${results.length} results from ${baseUrl}`);
+    const redactedUrl = (() => { try { return new URL(baseUrl).origin; } catch { return '(invalid)'; } })();
+    logger.info(`[Torznab] ${results.length} results from ${redactedUrl}`);
     return results;
   } catch (err) {
     logger.warn(`[Torznab] ${err.message}`);
@@ -79,12 +91,16 @@ function normalise(item, meta) {
 
   const parsed = parseTitle(title);
 
+  const parsedSeeders = parseInt(seeders, 10);
+  const parsedPeers   = parseInt(peers, 10);
+  const parsedSize    = parseInt(sizeEl || encLen || '0', 10);
+
   return {
     infoHash,
     title,
-    seeders:  seeders != null ? parseInt(seeders, 10) : 0,
-    leechers: peers != null ? Math.max(0, parseInt(peers, 10) - (parseInt(seeders, 10) || 0)) : 0,
-    size:     parseInt(sizeEl || encLen || '0', 10),
+    seeders:  Number.isFinite(parsedSeeders) ? parsedSeeders : 0,
+    leechers: Number.isFinite(parsedPeers) ? Math.max(0, parsedPeers - (parsedSeeders || 0)) : 0,
+    size:     Number.isFinite(parsedSize) ? parsedSize : 0,
     provider: 'Torznab',
     imdbId:   meta.imdbId || null,
     ...parsed,

--- a/scraper/providers/torznab.js
+++ b/scraper/providers/torznab.js
@@ -1,0 +1,133 @@
+/**
+ * Torznab provider -- queries any Torznab-compatible endpoint (Jackett, Prowlarr, etc.).
+ * Conditionally active: returns [] when no torznabUrl is configured.
+ */
+import * as cheerio from 'cheerio';
+import { get } from '../lib/httpClient.js';
+import { parseTitle, buildSearchQuery } from '../lib/titleHelper.js';
+import { logger } from '../lib/logger.js';
+
+export const id   = 'torznab';
+export const name = 'Torznab';
+
+const CATEGORY_MOVIES = '2000';
+const CATEGORY_TV     = '5000';
+
+export async function scrape(meta) {
+  const baseUrl = meta.torznabUrl;
+  const apiKey  = meta.torznabApiKey;
+  if (!baseUrl) return [];
+
+  try {
+    const params = buildParams(meta, apiKey);
+
+    const { data } = await get(baseUrl, {
+      limiterKey: 'torznab',
+      timeout: 15_000,
+      params,
+    });
+
+    const $ = cheerio.load(data, { xmlMode: true });
+    const results = [];
+
+    $('item').each((_, el) => {
+      const item = $(el);
+      const record = normalise(item, meta);
+      if (record) results.push(record);
+    });
+
+    logger.info(`[Torznab] ${results.length} results from ${baseUrl}`);
+    return results;
+  } catch (err) {
+    logger.warn(`[Torznab] ${err.message}`);
+    return [];
+  }
+}
+
+function buildParams(meta, apiKey) {
+  const params = {};
+  if (apiKey) params.apikey = apiKey;
+
+  if (meta.imdbId && meta.type === 'movie') {
+    params.t = 'movie';
+    params.imdbid = meta.imdbId;
+  } else if (meta.imdbId && (meta.type === 'series' || meta.type === 'anime')) {
+    params.t = 'tvsearch';
+    params.imdbid = meta.imdbId;
+    if (meta.season != null) params.season = meta.season;
+    if (meta.episode != null) params.ep = meta.episode;
+  } else {
+    params.t = 'search';
+    params.q = buildSearchQuery(meta);
+    params.cat = meta.type === 'movie' ? CATEGORY_MOVIES : CATEGORY_TV;
+  }
+
+  return params;
+}
+
+function normalise(item, meta) {
+  const title = item.find('title').text().trim();
+  if (!title) return null;
+
+  const infoHash = extractInfoHash(item);
+  if (!infoHash) return null;
+
+  const seeders  = attrValue(item, 'seeders');
+  const peers    = attrValue(item, 'peers');
+  const sizeEl   = item.find('size').text();
+  const encLen   = item.find('enclosure').attr('length');
+
+  const parsed = parseTitle(title);
+
+  return {
+    infoHash,
+    title,
+    seeders:  seeders != null ? parseInt(seeders, 10) : 0,
+    leechers: peers != null ? Math.max(0, parseInt(peers, 10) - (parseInt(seeders, 10) || 0)) : 0,
+    size:     parseInt(sizeEl || encLen || '0', 10),
+    provider: 'Torznab',
+    imdbId:   meta.imdbId || null,
+    ...parsed,
+  };
+}
+
+function extractInfoHash(item) {
+  const hashAttr = attrValue(item, 'infohash');
+  if (hashAttr) return hashAttr.toLowerCase();
+
+  const link = item.find('link').text().trim();
+  const magnetMatch = link.match(/magnet:\?xt=urn:btih:([a-fA-F0-9]{40}|[a-zA-Z2-7]{32})/i);
+  if (magnetMatch) {
+    const hash = magnetMatch[1];
+    return hash.length === 32 ? base32ToHex(hash) : hash.toLowerCase();
+  }
+
+  const comments = item.find('comments').text().trim();
+  const commentsMatch = comments.match(/magnet:\?xt=urn:btih:([a-fA-F0-9]{40}|[a-zA-Z2-7]{32})/i);
+  if (commentsMatch) {
+    const hash = commentsMatch[1];
+    return hash.length === 32 ? base32ToHex(hash) : hash.toLowerCase();
+  }
+
+  return null;
+}
+
+function attrValue(item, attrName) {
+  const el = item.find(`torznab\\:attr[name="${attrName}"], attr[name="${attrName}"]`);
+  return el.length ? el.attr('value') : null;
+}
+
+function base32ToHex(base32) {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  let bits = '';
+  for (const c of base32.toUpperCase()) {
+    const val = alphabet.indexOf(c);
+    if (val === -1) return null;
+    bits += val.toString(2).padStart(5, '0');
+  }
+  let hex = '';
+  for (let i = 0; i + 4 <= bits.length; i += 4) {
+    hex += parseInt(bits.substring(i, i + 4), 2).toString(16);
+  }
+  return hex.length === 40 ? hex : null;
+}


### PR DESCRIPTION
## Summary
- Add a Torznab scraper provider that queries any Torznab-compatible endpoint (Jackett, Prowlarr, or standalone)
- Users configure Torznab URL and API key in the configure page; provider is conditionally active only when a URL is set
- Add Jackett and Prowlarr as optional Docker Compose services using profiles (`--profile jackett` / `--profile prowlarr`)

## Test plan
- [ ] Start addon+scraper with `docker compose up`, verify Torznab section appears on configure page
- [ ] Enter a Torznab endpoint URL and API key, verify manifest URL contains `torznabUrl` and `torznabKey`
- [ ] Test with Jackett: `docker compose --profile jackett up`, configure at `:9117`, use Torznab URL in Magnetio
- [ ] Search for a movie/series and verify Torznab results appear alongside regular provider results

Generated with Claude Code