### PR TITLE
Move Redis to HDD and expand prewarm to 500+200 titles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,13 +13,13 @@ services:
     environment:
       - PORT=8080
       - REDIS_URI=redis://redis:6379
-      - CACHE_TTL_STREAMS=${CACHE_TTL_STREAMS:-3600}
+      - CACHE_TTL_STREAMS=${CACHE_TTL_STREAMS:-86400}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - PREWARM_ENABLED=${PREWARM_ENABLED:-true}
-      - PREWARM_SCHEDULE=${PREWARM_SCHEDULE:-0 4 * * *}
-      - PREWARM_MOVIE_LIMIT=${PREWARM_MOVIE_LIMIT:-50}
-      - PREWARM_SERIES_LIMIT=${PREWARM_SERIES_LIMIT:-20}
-      - PREWARM_CACHE_TTL=${PREWARM_CACHE_TTL:-14400}
+      - PREWARM_SCHEDULE=${PREWARM_SCHEDULE:-0 3 * * *}
+      - PREWARM_MOVIE_LIMIT=${PREWARM_MOVIE_LIMIT:-500}
+      - PREWARM_SERIES_LIMIT=${PREWARM_SERIES_LIMIT:-200}
+      - PREWARM_CACHE_TTL=${PREWARM_CACHE_TTL:-86400}
     depends_on:
       redis:
         condition: service_healthy
@@ -75,9 +75,9 @@ services:
     image: redis:7-alpine
     container_name: magnetio_redis
     restart: unless-stopped
-    command: redis-server --save 60 1 --loglevel warning
+    command: redis-server --save 60 1 --loglevel warning --maxmemory 512mb --maxmemory-policy allkeys-lru
     volumes:
-      - redis_data:/data
+      - ${REDIS_DATA_PATH:-redis_data}:/data
     networks:
       - magnetio_net
     healthcheck:


### PR DESCRIPTION
## Summary
- Point Redis data volume to configurable `REDIS_DATA_PATH` for HDD storage
- Set Redis maxmemory to 512MB with LRU eviction
- Increase stream cache TTL from 1 hour to 24 hours
- Expand daily prewarm from 50+20 to 500 movies + 200 series
- Prewarm runs at 3 AM daily

Generated with Claude Code