### PR TITLE
Add Magnetio brand assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 <p align="center">
+  <img src="./README_assets/magnetio-wordmark.svg" alt="Magnetio" width="720" />
+</p>
+
+<p align="center">
   <img src="https://img.shields.io/badge/Magnetio-v1.1.5-10b981?style=for-the-badge&labelColor=1a1a2e" alt="Magnetio Version" />
   <img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=for-the-badge&labelColor=1a1a2e" alt="License" />
   <img src="https://img.shields.io/badge/node-%3E%3D18-brightgreen?style=for-the-badge&logo=node.js&labelColor=1a1a2e" alt="Node.js" />
@@ -7,8 +11,6 @@
   <img src="https://img.shields.io/badge/debrid-8%20services-ff6b6b?style=for-the-badge&labelColor=1a1a2e" alt="Debrid Services" />
   <img src="https://img.shields.io/badge/torznab-Jackett%20%2F%20Prowlarr-f5a623?style=for-the-badge&labelColor=1a1a2e" alt="Torznab Jackett Prowlarr" />
 </p>
-
-<h1 align="center">Magnetio</h1>
 
 <p align="center">
   <strong>A fully self-hosted Stremio addon with 22+ torrent providers, 8 debrid services, Torznab/Jackett/Prowlarr integration, and TMDB recommendations.</strong>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 <p align="center">
+  <img src="./README_assets/magnetio-logo.svg" alt="Magnetio logo" width="128" />
+</p>
+
+<p align="center">
   <img src="./README_assets/magnetio-wordmark.svg" alt="Magnetio" width="720" />
 </p>
 

--- a/README_assets/magnetio-logo.svg
+++ b/README_assets/magnetio-logo.svg
@@ -1,0 +1,71 @@
+<svg width="1024" height="1024" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Magnetio Logo</title>
+  <desc id="desc">A modern vector logo for Magnetio, combining a magnet shape, torrent nodes, and streaming motion.</desc>
+
+  <defs>
+    <linearGradient id="bg" x1="160" y1="96" x2="864" y2="928" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#111827"/>
+      <stop offset="0.48" stop-color="#1A1A2E"/>
+      <stop offset="1" stop-color="#0F172A"/>
+    </linearGradient>
+
+    <linearGradient id="magnet" x1="251" y1="225" x2="773" y2="799" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#7B5BF5"/>
+      <stop offset="0.5" stop-color="#22D3EE"/>
+      <stop offset="1" stop-color="#10B981"/>
+    </linearGradient>
+
+    <linearGradient id="accent" x1="286" y1="298" x2="740" y2="737" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F5A623"/>
+      <stop offset="1" stop-color="#FF6B6B"/>
+    </linearGradient>
+
+    <filter id="softShadow" x="80" y="80" width="864" height="864" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="28" stdDeviation="36" flood-color="#000000" flood-opacity="0.35"/>
+    </filter>
+
+    <filter id="glow" x="120" y="120" width="784" height="784" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="16" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0.0627 0 0 0 0 0.725 0 0 0 0 0.506 0 0 0 0.55 0"/>
+      <feBlend in="SourceGraphic" mode="screen"/>
+    </filter>
+
+    <clipPath id="roundedSquare">
+      <rect x="96" y="96" width="832" height="832" rx="208"/>
+    </clipPath>
+  </defs>
+
+  <rect x="96" y="96" width="832" height="832" rx="208" fill="url(#bg)" filter="url(#softShadow)"/>
+
+  <g clip-path="url(#roundedSquare)" opacity="0.4">
+    <circle cx="180" cy="210" r="260" fill="#7B5BF5" opacity="0.18"/>
+    <circle cx="858" cy="828" r="310" fill="#10B981" opacity="0.16"/>
+    <path d="M164 720C322 632 463 606 612 652C751 695 835 656 932 567" stroke="#22D3EE" stroke-width="18" stroke-linecap="round" opacity="0.12"/>
+    <path d="M116 344C276 406 419 405 546 343C670 282 781 293 928 370" stroke="#7B5BF5" stroke-width="18" stroke-linecap="round" opacity="0.16"/>
+  </g>
+
+  <!-- Main magnet mark -->
+  <g filter="url(#glow)">
+    <path d="M326 284H438V543C438 586.078 472.922 621 516 621C559.078 621 594 586.078 594 543V284H706V548C706 652.934 620.934 738 516 738C411.066 738 326 652.934 326 548V284Z" fill="url(#magnet)"/>
+    <path d="M326 284H438V404H326V284Z" fill="url(#accent)"/>
+    <path d="M594 284H706V404H594V284Z" fill="url(#accent)"/>
+    <path d="M326 422H438V510H326V422Z" fill="#E5E7EB" opacity="0.92"/>
+    <path d="M594 422H706V510H594V422Z" fill="#E5E7EB" opacity="0.92"/>
+  </g>
+
+  <!-- Streaming play core -->
+  <path d="M494 420C494 404.653 510.817 395.251 523.884 403.302L624.964 465.573C637.373 473.218 637.373 491.235 624.964 498.88L523.884 561.151C510.817 569.202 494 559.8 494 544.453V420Z" fill="#FFFFFF" opacity="0.96"/>
+
+  <!-- Torrent nodes -->
+  <g stroke="#E5E7EB" stroke-width="18" stroke-linecap="round" stroke-linejoin="round" opacity="0.92">
+    <path d="M286 610L222 674"/>
+    <path d="M746 610L810 674"/>
+    <path d="M516 744V822"/>
+  </g>
+  <circle cx="222" cy="674" r="34" fill="#7B5BF5" stroke="#E5E7EB" stroke-width="14"/>
+  <circle cx="810" cy="674" r="34" fill="#10B981" stroke="#E5E7EB" stroke-width="14"/>
+  <circle cx="516" cy="822" r="34" fill="#22D3EE" stroke="#E5E7EB" stroke-width="14"/>
+
+  <!-- Inner highlight -->
+  <path d="M390 292V548C390 617.588 446.412 674 516 674C560.178 674 598.997 651.264 621.486 616.861" stroke="#FFFFFF" stroke-width="18" stroke-linecap="round" opacity="0.18"/>
+</svg>

--- a/README_assets/magnetio-wordmark.svg
+++ b/README_assets/magnetio-wordmark.svg
@@ -1,0 +1,54 @@
+<svg width="1600" height="480" viewBox="0 0 1600 480" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Magnetio Wordmark</title>
+  <desc id="desc">Horizontal vector logo for Magnetio, with magnet streaming icon and wordmark.</desc>
+
+  <defs>
+    <linearGradient id="bg" x1="44" y1="40" x2="396" y2="440" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#111827"/>
+      <stop offset="0.48" stop-color="#1A1A2E"/>
+      <stop offset="1" stop-color="#0F172A"/>
+    </linearGradient>
+    <linearGradient id="magnet" x1="106" y1="92" x2="334" y2="380" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#7B5BF5"/>
+      <stop offset="0.5" stop-color="#22D3EE"/>
+      <stop offset="1" stop-color="#10B981"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="124" y1="124" x2="326" y2="334" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F5A623"/>
+      <stop offset="1" stop-color="#FF6B6B"/>
+    </linearGradient>
+    <linearGradient id="textGrad" x1="488" y1="132" x2="1275" y2="338" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F8FAFC"/>
+      <stop offset="0.55" stop-color="#DDE9FF"/>
+      <stop offset="1" stop-color="#A7F3D0"/>
+    </linearGradient>
+    <filter id="shadow" x="0" y="0" width="480" height="480" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#000000" flood-opacity="0.32"/>
+    </filter>
+  </defs>
+
+  <g filter="url(#shadow)">
+    <rect x="40" y="40" width="400" height="400" rx="104" fill="url(#bg)"/>
+    <circle cx="86" cy="90" r="130" fill="#7B5BF5" opacity="0.14"/>
+    <circle cx="392" cy="394" r="152" fill="#10B981" opacity="0.13"/>
+
+    <path d="M142 126H194V250C194 278.167 216.833 301 245 301C273.167 301 296 278.167 296 250V126H348V252C348 309.438 302.438 355 245 355C187.562 355 142 309.438 142 252V126Z" fill="url(#magnet)"/>
+    <path d="M142 126H194V183H142V126Z" fill="url(#accent)"/>
+    <path d="M296 126H348V183H296V126Z" fill="url(#accent)"/>
+    <path d="M142 193H194V232H142V193Z" fill="#E5E7EB" opacity="0.92"/>
+    <path d="M296 193H348V232H296V193Z" fill="#E5E7EB" opacity="0.92"/>
+    <path d="M233 190C233 181.941 241.835 177.003 248.695 181.23L296.005 210.384C302.519 214.398 302.519 223.857 296.005 227.871L248.695 257.025C241.835 261.252 233 256.314 233 248.255V190Z" fill="#FFFFFF" opacity="0.96"/>
+
+    <g stroke="#E5E7EB" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity="0.92">
+      <path d="M123 293L94 322"/>
+      <path d="M368 293L397 322"/>
+      <path d="M245 357V391"/>
+    </g>
+    <circle cx="94" cy="322" r="16" fill="#7B5BF5" stroke="#E5E7EB" stroke-width="7"/>
+    <circle cx="397" cy="322" r="16" fill="#10B981" stroke="#E5E7EB" stroke-width="7"/>
+    <circle cx="245" cy="391" r="16" fill="#22D3EE" stroke="#E5E7EB" stroke-width="7"/>
+  </g>
+
+  <text x="500" y="244" fill="url(#textGrad)" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="132" font-weight="800" letter-spacing="-5">Magnetio</text>
+  <text x="506" y="314" fill="#94A3B8" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="34" font-weight="500" letter-spacing="0.4">self-hosted Stremio addon • torrent + debrid streaming</text>
+</svg>

--- a/addon/lib/configuration.js
+++ b/addon/lib/configuration.js
@@ -1,5 +1,8 @@
 import { TorrentProvider, SortType, SizeLimit } from './types.js';
 
+const ASSET_BASE_URL = `${(process.env.ADDON_PUBLIC_URL || 'https://magnetio.peterdsp.dev').replace(/\/$/, '')}/static`;
+const PRESET_LOGO = `${ASSET_BASE_URL}/magnetio-logo.svg`;
+
 const PublicProviderAliases = {
   s1: TorrentProvider.YTS,
   s2: TorrentProvider.EZTV,
@@ -27,7 +30,7 @@ export const PreConfigurations = {
   lite: {
     name: 'Magnetio Lite',
     description: 'Lightweight configuration – English-only, no cam/screener sources',
-    logo:        'https://i.imgur.com/magnetio-lite.png',
+    logo:        PRESET_LOGO,
     overrideId:  'lite',
     providers:   [TorrentProvider.YTS, TorrentProvider.EZTV, TorrentProvider.TORRENTGALAXY],
     qualities:   ['4k', '1080p', '720p'],
@@ -42,7 +45,7 @@ export const PreConfigurations = {
   brazuca: {
     name: 'Magnetio Brazuca',
     description: 'Brazilian-focused configuration with Portuguese language sources',
-    logo:        'https://i.imgur.com/magnetio-brazuca.png',
+    logo:        PRESET_LOGO,
     overrideId:  'brazuca',
     providers:   [TorrentProvider.YTS, TorrentProvider.EZTV, TorrentProvider.TORRENTGALAXY, TorrentProvider.RUTOR],
     qualities:   [],

--- a/addon/lib/landingTemplate.js
+++ b/addon/lib/landingTemplate.js
@@ -50,6 +50,8 @@ function escapeHtml(str) {
 }
 
 export function landingTemplate(manifest, initialConfig = {}) {
+  const brandLogo = escapeHtml(manifest.logo || '');
+  const brandBackground = escapeHtml(manifest.background || manifest.logo || '');
   const initialState = escapeJsonForHtml({
     sort: initialConfig.sort ?? 'qualityseeders',
     limit: initialConfig.limit ?? 10,
@@ -89,7 +91,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
   <meta property="og:description" content="Stream anything with 22+ providers, 8 debrid services, Torznab support, and TMDB recommendations. Fully self-hosted, your API keys never leave your server." />
   <meta property="og:url" content="https://magnetio.peterdsp.dev/" />
   <meta property="og:site_name" content="Magnetio" />
-  <meta property="og:image" content="https://magnetio.peterdsp.dev/og-image.png" />
+  <meta property="og:image" content="${brandLogo}" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
 
@@ -97,7 +99,9 @@ export function landingTemplate(manifest, initialConfig = {}) {
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Magnetio - Self-Hosted Stremio Addon" />
   <meta name="twitter:description" content="Stream anything with 22+ providers, 8 debrid services, and Torznab support. Open source and self-hosted." />
-  <meta name="twitter:image" content="https://magnetio.peterdsp.dev/og-image.png" />
+  <meta name="twitter:image" content="${brandLogo}" />
+  <link rel="icon" href="${brandLogo}" type="image/svg+xml" />
+  <link rel="apple-touch-icon" href="${brandLogo}" />
 
   <!-- JSON-LD Structured Data -->
   <script type="application/ld+json">
@@ -194,6 +198,13 @@ export function landingTemplate(manifest, initialConfig = {}) {
       gap: 12px;
     }
 
+    .nav-logo {
+      width: 32px;
+      height: 32px;
+      display: block;
+      flex-shrink: 0;
+    }
+
     .nav-brand {
       font-weight: 800;
       font-size: 1.15rem;
@@ -243,6 +254,17 @@ export function landingTemplate(manifest, initialConfig = {}) {
       text-align: center;
       padding: 120px 24px 80px;
       overflow: hidden;
+    }
+
+    .hero-watermark {
+      position: absolute;
+      top: 120px;
+      left: 50%;
+      width: min(520px, 70vw);
+      height: auto;
+      opacity: 0.06;
+      transform: translateX(-50%);
+      pointer-events: none;
     }
 
     .hero-orb {
@@ -303,6 +325,19 @@ export function landingTemplate(manifest, initialConfig = {}) {
       position: relative;
       z-index: 1;
       max-width: 800px;
+    }
+
+    .hero-brand {
+      display: flex;
+      justify-content: center;
+      margin-bottom: 28px;
+    }
+
+    .hero-brand img {
+      width: min(560px, 82vw);
+      height: auto;
+      display: block;
+      filter: drop-shadow(0 24px 80px rgba(0, 0, 0, 0.28));
     }
 
     .hero-headline {
@@ -821,6 +856,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
     /* ---- Responsive ---- */
     @media (max-width: 980px) {
       .hero-headline { font-size: 2.8rem; }
+      .hero-watermark { width: min(440px, 76vw); }
       .features-grid { grid-template-columns: repeat(2, 1fr); }
       .stats-bar { flex-wrap: wrap; margin-top: 0; }
       .stat-item { flex: 1 1 45%; }
@@ -839,8 +875,12 @@ export function landingTemplate(manifest, initialConfig = {}) {
 
     @media (max-width: 640px) {
       .navbar { padding: 0 16px; }
+      .nav-logo { width: 28px; height: 28px; }
       .nav-version { display: none; }
       .hero { padding: 100px 16px 60px; }
+      .hero-watermark { width: min(300px, 74vw); top: 132px; }
+      .hero-brand { margin-bottom: 22px; }
+      .hero-brand img { width: min(420px, 84vw); }
       .hero-headline { font-size: 2rem; }
       .hero-sub { font-size: 0.95rem; }
       .features-grid { grid-template-columns: 1fr; }
@@ -857,6 +897,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
   <!-- Navbar -->
   <nav class="navbar">
     <div class="nav-left">
+      <img class="nav-logo" src="${brandLogo}" alt="" aria-hidden="true" />
       <span class="nav-brand">${escapeHtml(manifest.name)}</span>
       <span class="nav-version">v${escapeHtml(manifest.version)}</span>
     </div>
@@ -865,10 +906,14 @@ export function landingTemplate(manifest, initialConfig = {}) {
 
   <!-- Hero -->
   <section class="hero">
+    <img class="hero-watermark" src="${brandLogo}" alt="" aria-hidden="true" />
     <div class="hero-orb hero-orb-1"></div>
     <div class="hero-orb hero-orb-2"></div>
     <div class="hero-orb hero-orb-3"></div>
     <div class="hero-content">
+      <div class="hero-brand">
+        <img src="${brandBackground}" alt="${escapeHtml(manifest.name)}" />
+      </div>
       <h1 class="hero-headline">
         <span class="gradient-text">Stream anything.</span><br />Own your setup.
       </h1>

--- a/addon/lib/manifest.js
+++ b/addon/lib/manifest.js
@@ -4,7 +4,9 @@ import { MochOptions } from '../moch/options.js';
 const ADDON_ID      = 'com.magnetio.addon';
 const ADDON_VERSION = '1.1.5';
 const ADDON_NAME    = 'Magnetio';
-const ADDON_LOGO    = 'https://i.imgur.com/magnetio.png';
+const ASSET_BASE_URL = `${(process.env.ADDON_PUBLIC_URL || 'https://magnetio.peterdsp.dev').replace(/\/$/, '')}/static`;
+const ADDON_LOGO = `${ASSET_BASE_URL}/magnetio-logo.svg`;
+const ADDON_BACKGROUND = `${ASSET_BASE_URL}/magnetio-wordmark.svg`;
 
 /**
  * Build the full addon manifest for a given config.
@@ -18,7 +20,7 @@ export function manifest(config) {
     name:        override?.name        ?? getName(config),
     description: override?.description ?? getDescription(config),
     logo:        override?.logo        ?? ADDON_LOGO,
-    background:  'https://i.imgur.com/magnetio-bg.jpg',
+    background:  ADDON_BACKGROUND,
     types:       ['movie', 'series', 'anime'],
     resources:   getResources(),
     catalogs:    getCatalogs(config),
@@ -44,7 +46,7 @@ export function dummyManifest() {
     name:        ADDON_NAME,
     description: `${ADDON_NAME} - configure sources, subtitles and debrid services at /configure`,
     logo:        ADDON_LOGO,
-    background:  'https://i.imgur.com/magnetio-bg.jpg',
+    background:  ADDON_BACKGROUND,
     types:       ['movie', 'series', 'anime'],
     resources:   getResources(),
     catalogs:    [],

--- a/addon/static/magnetio-logo.svg
+++ b/addon/static/magnetio-logo.svg
@@ -1,0 +1,71 @@
+<svg width="1024" height="1024" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Magnetio Logo</title>
+  <desc id="desc">A modern vector logo for Magnetio, combining a magnet shape, torrent nodes, and streaming motion.</desc>
+
+  <defs>
+    <linearGradient id="bg" x1="160" y1="96" x2="864" y2="928" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#111827"/>
+      <stop offset="0.48" stop-color="#1A1A2E"/>
+      <stop offset="1" stop-color="#0F172A"/>
+    </linearGradient>
+
+    <linearGradient id="magnet" x1="251" y1="225" x2="773" y2="799" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#7B5BF5"/>
+      <stop offset="0.5" stop-color="#22D3EE"/>
+      <stop offset="1" stop-color="#10B981"/>
+    </linearGradient>
+
+    <linearGradient id="accent" x1="286" y1="298" x2="740" y2="737" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F5A623"/>
+      <stop offset="1" stop-color="#FF6B6B"/>
+    </linearGradient>
+
+    <filter id="softShadow" x="80" y="80" width="864" height="864" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="28" stdDeviation="36" flood-color="#000000" flood-opacity="0.35"/>
+    </filter>
+
+    <filter id="glow" x="120" y="120" width="784" height="784" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="16" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0.0627 0 0 0 0 0.725 0 0 0 0 0.506 0 0 0 0.55 0"/>
+      <feBlend in="SourceGraphic" mode="screen"/>
+    </filter>
+
+    <clipPath id="roundedSquare">
+      <rect x="96" y="96" width="832" height="832" rx="208"/>
+    </clipPath>
+  </defs>
+
+  <rect x="96" y="96" width="832" height="832" rx="208" fill="url(#bg)" filter="url(#softShadow)"/>
+
+  <g clip-path="url(#roundedSquare)" opacity="0.4">
+    <circle cx="180" cy="210" r="260" fill="#7B5BF5" opacity="0.18"/>
+    <circle cx="858" cy="828" r="310" fill="#10B981" opacity="0.16"/>
+    <path d="M164 720C322 632 463 606 612 652C751 695 835 656 932 567" stroke="#22D3EE" stroke-width="18" stroke-linecap="round" opacity="0.12"/>
+    <path d="M116 344C276 406 419 405 546 343C670 282 781 293 928 370" stroke="#7B5BF5" stroke-width="18" stroke-linecap="round" opacity="0.16"/>
+  </g>
+
+  <!-- Main magnet mark -->
+  <g filter="url(#glow)">
+    <path d="M326 284H438V543C438 586.078 472.922 621 516 621C559.078 621 594 586.078 594 543V284H706V548C706 652.934 620.934 738 516 738C411.066 738 326 652.934 326 548V284Z" fill="url(#magnet)"/>
+    <path d="M326 284H438V404H326V284Z" fill="url(#accent)"/>
+    <path d="M594 284H706V404H594V284Z" fill="url(#accent)"/>
+    <path d="M326 422H438V510H326V422Z" fill="#E5E7EB" opacity="0.92"/>
+    <path d="M594 422H706V510H594V422Z" fill="#E5E7EB" opacity="0.92"/>
+  </g>
+
+  <!-- Streaming play core -->
+  <path d="M494 420C494 404.653 510.817 395.251 523.884 403.302L624.964 465.573C637.373 473.218 637.373 491.235 624.964 498.88L523.884 561.151C510.817 569.202 494 559.8 494 544.453V420Z" fill="#FFFFFF" opacity="0.96"/>
+
+  <!-- Torrent nodes -->
+  <g stroke="#E5E7EB" stroke-width="18" stroke-linecap="round" stroke-linejoin="round" opacity="0.92">
+    <path d="M286 610L222 674"/>
+    <path d="M746 610L810 674"/>
+    <path d="M516 744V822"/>
+  </g>
+  <circle cx="222" cy="674" r="34" fill="#7B5BF5" stroke="#E5E7EB" stroke-width="14"/>
+  <circle cx="810" cy="674" r="34" fill="#10B981" stroke="#E5E7EB" stroke-width="14"/>
+  <circle cx="516" cy="822" r="34" fill="#22D3EE" stroke="#E5E7EB" stroke-width="14"/>
+
+  <!-- Inner highlight -->
+  <path d="M390 292V548C390 617.588 446.412 674 516 674C560.178 674 598.997 651.264 621.486 616.861" stroke="#FFFFFF" stroke-width="18" stroke-linecap="round" opacity="0.18"/>
+</svg>

--- a/addon/static/magnetio-wordmark.svg
+++ b/addon/static/magnetio-wordmark.svg
@@ -1,0 +1,54 @@
+<svg width="1600" height="480" viewBox="0 0 1600 480" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Magnetio Wordmark</title>
+  <desc id="desc">Horizontal vector logo for Magnetio, with magnet streaming icon and wordmark.</desc>
+
+  <defs>
+    <linearGradient id="bg" x1="44" y1="40" x2="396" y2="440" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#111827"/>
+      <stop offset="0.48" stop-color="#1A1A2E"/>
+      <stop offset="1" stop-color="#0F172A"/>
+    </linearGradient>
+    <linearGradient id="magnet" x1="106" y1="92" x2="334" y2="380" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#7B5BF5"/>
+      <stop offset="0.5" stop-color="#22D3EE"/>
+      <stop offset="1" stop-color="#10B981"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="124" y1="124" x2="326" y2="334" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F5A623"/>
+      <stop offset="1" stop-color="#FF6B6B"/>
+    </linearGradient>
+    <linearGradient id="textGrad" x1="488" y1="132" x2="1275" y2="338" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F8FAFC"/>
+      <stop offset="0.55" stop-color="#DDE9FF"/>
+      <stop offset="1" stop-color="#A7F3D0"/>
+    </linearGradient>
+    <filter id="shadow" x="0" y="0" width="480" height="480" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#000000" flood-opacity="0.32"/>
+    </filter>
+  </defs>
+
+  <g filter="url(#shadow)">
+    <rect x="40" y="40" width="400" height="400" rx="104" fill="url(#bg)"/>
+    <circle cx="86" cy="90" r="130" fill="#7B5BF5" opacity="0.14"/>
+    <circle cx="392" cy="394" r="152" fill="#10B981" opacity="0.13"/>
+
+    <path d="M142 126H194V250C194 278.167 216.833 301 245 301C273.167 301 296 278.167 296 250V126H348V252C348 309.438 302.438 355 245 355C187.562 355 142 309.438 142 252V126Z" fill="url(#magnet)"/>
+    <path d="M142 126H194V183H142V126Z" fill="url(#accent)"/>
+    <path d="M296 126H348V183H296V126Z" fill="url(#accent)"/>
+    <path d="M142 193H194V232H142V193Z" fill="#E5E7EB" opacity="0.92"/>
+    <path d="M296 193H348V232H296V193Z" fill="#E5E7EB" opacity="0.92"/>
+    <path d="M233 190C233 181.941 241.835 177.003 248.695 181.23L296.005 210.384C302.519 214.398 302.519 223.857 296.005 227.871L248.695 257.025C241.835 261.252 233 256.314 233 248.255V190Z" fill="#FFFFFF" opacity="0.96"/>
+
+    <g stroke="#E5E7EB" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity="0.92">
+      <path d="M123 293L94 322"/>
+      <path d="M368 293L397 322"/>
+      <path d="M245 357V391"/>
+    </g>
+    <circle cx="94" cy="322" r="16" fill="#7B5BF5" stroke="#E5E7EB" stroke-width="7"/>
+    <circle cx="397" cy="322" r="16" fill="#10B981" stroke="#E5E7EB" stroke-width="7"/>
+    <circle cx="245" cy="391" r="16" fill="#22D3EE" stroke="#E5E7EB" stroke-width="7"/>
+  </g>
+
+  <text x="500" y="244" fill="url(#textGrad)" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="132" font-weight="800" letter-spacing="-5">Magnetio</text>
+  <text x="506" y="314" fill="#94A3B8" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="34" font-weight="500" letter-spacing="0.4">self-hosted Stremio addon • torrent + debrid streaming</text>
+</svg>

--- a/site/assets/magnetio-logo.svg
+++ b/site/assets/magnetio-logo.svg
@@ -1,0 +1,71 @@
+<svg width="1024" height="1024" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Magnetio Logo</title>
+  <desc id="desc">A modern vector logo for Magnetio, combining a magnet shape, torrent nodes, and streaming motion.</desc>
+
+  <defs>
+    <linearGradient id="bg" x1="160" y1="96" x2="864" y2="928" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#111827"/>
+      <stop offset="0.48" stop-color="#1A1A2E"/>
+      <stop offset="1" stop-color="#0F172A"/>
+    </linearGradient>
+
+    <linearGradient id="magnet" x1="251" y1="225" x2="773" y2="799" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#7B5BF5"/>
+      <stop offset="0.5" stop-color="#22D3EE"/>
+      <stop offset="1" stop-color="#10B981"/>
+    </linearGradient>
+
+    <linearGradient id="accent" x1="286" y1="298" x2="740" y2="737" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F5A623"/>
+      <stop offset="1" stop-color="#FF6B6B"/>
+    </linearGradient>
+
+    <filter id="softShadow" x="80" y="80" width="864" height="864" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="28" stdDeviation="36" flood-color="#000000" flood-opacity="0.35"/>
+    </filter>
+
+    <filter id="glow" x="120" y="120" width="784" height="784" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="16" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0.0627 0 0 0 0 0.725 0 0 0 0 0.506 0 0 0 0.55 0"/>
+      <feBlend in="SourceGraphic" mode="screen"/>
+    </filter>
+
+    <clipPath id="roundedSquare">
+      <rect x="96" y="96" width="832" height="832" rx="208"/>
+    </clipPath>
+  </defs>
+
+  <rect x="96" y="96" width="832" height="832" rx="208" fill="url(#bg)" filter="url(#softShadow)"/>
+
+  <g clip-path="url(#roundedSquare)" opacity="0.4">
+    <circle cx="180" cy="210" r="260" fill="#7B5BF5" opacity="0.18"/>
+    <circle cx="858" cy="828" r="310" fill="#10B981" opacity="0.16"/>
+    <path d="M164 720C322 632 463 606 612 652C751 695 835 656 932 567" stroke="#22D3EE" stroke-width="18" stroke-linecap="round" opacity="0.12"/>
+    <path d="M116 344C276 406 419 405 546 343C670 282 781 293 928 370" stroke="#7B5BF5" stroke-width="18" stroke-linecap="round" opacity="0.16"/>
+  </g>
+
+  <!-- Main magnet mark -->
+  <g filter="url(#glow)">
+    <path d="M326 284H438V543C438 586.078 472.922 621 516 621C559.078 621 594 586.078 594 543V284H706V548C706 652.934 620.934 738 516 738C411.066 738 326 652.934 326 548V284Z" fill="url(#magnet)"/>
+    <path d="M326 284H438V404H326V284Z" fill="url(#accent)"/>
+    <path d="M594 284H706V404H594V284Z" fill="url(#accent)"/>
+    <path d="M326 422H438V510H326V422Z" fill="#E5E7EB" opacity="0.92"/>
+    <path d="M594 422H706V510H594V422Z" fill="#E5E7EB" opacity="0.92"/>
+  </g>
+
+  <!-- Streaming play core -->
+  <path d="M494 420C494 404.653 510.817 395.251 523.884 403.302L624.964 465.573C637.373 473.218 637.373 491.235 624.964 498.88L523.884 561.151C510.817 569.202 494 559.8 494 544.453V420Z" fill="#FFFFFF" opacity="0.96"/>
+
+  <!-- Torrent nodes -->
+  <g stroke="#E5E7EB" stroke-width="18" stroke-linecap="round" stroke-linejoin="round" opacity="0.92">
+    <path d="M286 610L222 674"/>
+    <path d="M746 610L810 674"/>
+    <path d="M516 744V822"/>
+  </g>
+  <circle cx="222" cy="674" r="34" fill="#7B5BF5" stroke="#E5E7EB" stroke-width="14"/>
+  <circle cx="810" cy="674" r="34" fill="#10B981" stroke="#E5E7EB" stroke-width="14"/>
+  <circle cx="516" cy="822" r="34" fill="#22D3EE" stroke="#E5E7EB" stroke-width="14"/>
+
+  <!-- Inner highlight -->
+  <path d="M390 292V548C390 617.588 446.412 674 516 674C560.178 674 598.997 651.264 621.486 616.861" stroke="#FFFFFF" stroke-width="18" stroke-linecap="round" opacity="0.18"/>
+</svg>

--- a/site/assets/magnetio-wordmark.svg
+++ b/site/assets/magnetio-wordmark.svg
@@ -1,0 +1,54 @@
+<svg width="1600" height="480" viewBox="0 0 1600 480" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Magnetio Wordmark</title>
+  <desc id="desc">Horizontal vector logo for Magnetio, with magnet streaming icon and wordmark.</desc>
+
+  <defs>
+    <linearGradient id="bg" x1="44" y1="40" x2="396" y2="440" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#111827"/>
+      <stop offset="0.48" stop-color="#1A1A2E"/>
+      <stop offset="1" stop-color="#0F172A"/>
+    </linearGradient>
+    <linearGradient id="magnet" x1="106" y1="92" x2="334" y2="380" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#7B5BF5"/>
+      <stop offset="0.5" stop-color="#22D3EE"/>
+      <stop offset="1" stop-color="#10B981"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="124" y1="124" x2="326" y2="334" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F5A623"/>
+      <stop offset="1" stop-color="#FF6B6B"/>
+    </linearGradient>
+    <linearGradient id="textGrad" x1="488" y1="132" x2="1275" y2="338" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F8FAFC"/>
+      <stop offset="0.55" stop-color="#DDE9FF"/>
+      <stop offset="1" stop-color="#A7F3D0"/>
+    </linearGradient>
+    <filter id="shadow" x="0" y="0" width="480" height="480" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#000000" flood-opacity="0.32"/>
+    </filter>
+  </defs>
+
+  <g filter="url(#shadow)">
+    <rect x="40" y="40" width="400" height="400" rx="104" fill="url(#bg)"/>
+    <circle cx="86" cy="90" r="130" fill="#7B5BF5" opacity="0.14"/>
+    <circle cx="392" cy="394" r="152" fill="#10B981" opacity="0.13"/>
+
+    <path d="M142 126H194V250C194 278.167 216.833 301 245 301C273.167 301 296 278.167 296 250V126H348V252C348 309.438 302.438 355 245 355C187.562 355 142 309.438 142 252V126Z" fill="url(#magnet)"/>
+    <path d="M142 126H194V183H142V126Z" fill="url(#accent)"/>
+    <path d="M296 126H348V183H296V126Z" fill="url(#accent)"/>
+    <path d="M142 193H194V232H142V193Z" fill="#E5E7EB" opacity="0.92"/>
+    <path d="M296 193H348V232H296V193Z" fill="#E5E7EB" opacity="0.92"/>
+    <path d="M233 190C233 181.941 241.835 177.003 248.695 181.23L296.005 210.384C302.519 214.398 302.519 223.857 296.005 227.871L248.695 257.025C241.835 261.252 233 256.314 233 248.255V190Z" fill="#FFFFFF" opacity="0.96"/>
+
+    <g stroke="#E5E7EB" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" opacity="0.92">
+      <path d="M123 293L94 322"/>
+      <path d="M368 293L397 322"/>
+      <path d="M245 357V391"/>
+    </g>
+    <circle cx="94" cy="322" r="16" fill="#7B5BF5" stroke="#E5E7EB" stroke-width="7"/>
+    <circle cx="397" cy="322" r="16" fill="#10B981" stroke="#E5E7EB" stroke-width="7"/>
+    <circle cx="245" cy="391" r="16" fill="#22D3EE" stroke="#E5E7EB" stroke-width="7"/>
+  </g>
+
+  <text x="500" y="244" fill="url(#textGrad)" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="132" font-weight="800" letter-spacing="-5">Magnetio</text>
+  <text x="506" y="314" fill="#94A3B8" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="34" font-weight="500" letter-spacing="0.4">self-hosted Stremio addon • torrent + debrid streaming</text>
+</svg>

--- a/site/index.html
+++ b/site/index.html
@@ -7,13 +7,22 @@
   <meta name="description" content="Magnetio is an open source Stremio addon stack with torrent provider aggregation, debrid integrations, subtitles, and self-hosted deployment docs.">
   <meta name="theme-color" content="#09090b">
   <link rel="canonical" href="https://magnetio.peterdsp.dev/">
+  <meta property="og:title" content="Magnetio">
+  <meta property="og:description" content="Open source Stremio addon stack with torrent provider aggregation, debrid integrations, subtitles, and self-hosted deployment docs.">
+  <meta property="og:image" content="https://magnetio.peterdsp.dev/assets/magnetio-logo.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Magnetio">
+  <meta name="twitter:description" content="Open source Stremio addon stack with torrent provider aggregation, debrid integrations, subtitles, and self-hosted deployment docs.">
+  <meta name="twitter:image" content="https://magnetio.peterdsp.dev/assets/magnetio-logo.svg">
+  <link rel="icon" href="/assets/magnetio-logo.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/styles.css">
 </head>
 <body>
   <main class="shell">
     <header class="hero">
+      <img class="hero-watermark" src="/assets/magnetio-logo.svg" alt="" aria-hidden="true">
       <div class="eyebrow">Open source Stremio stack</div>
-      <h1>Magnetio</h1>
+      <img class="hero-wordmark" src="/assets/magnetio-wordmark.svg" alt="Magnetio">
       <p class="lede">
         Torrent aggregation, debrid support, subtitle sync, and a Raspberry Pi friendly deployment path.
         The public site is now static and hosted on GitHub Pages.

--- a/site/styles.css
+++ b/site/styles.css
@@ -22,12 +22,19 @@ body {
 }
 
 .hero {
+  position: relative;
+  overflow: hidden;
   padding: 40px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 32px;
   background: rgba(15, 23, 42, 0.72);
   backdrop-filter: blur(18px);
   box-shadow: 0 24px 60px rgba(0, 0, 0, 0.28);
+}
+
+.hero > * {
+  position: relative;
+  z-index: 1;
 }
 
 .eyebrow {
@@ -39,19 +46,30 @@ body {
   text-transform: uppercase;
 }
 
-h1 {
-  margin: 0;
-  font-size: clamp(44px, 7vw, 82px);
-  line-height: 0.94;
-  letter-spacing: -0.06em;
+.hero-wordmark {
+  display: block;
+  width: min(720px, 100%);
+  height: auto;
 }
 
 .lede {
   max-width: 760px;
-  margin: 20px 0 0;
+  margin: 18px 0 0;
   color: #cbd5e1;
   font-size: 20px;
   line-height: 1.6;
+}
+
+.hero-watermark {
+  position: absolute;
+  right: -60px;
+  bottom: -100px;
+  z-index: 0;
+  width: min(420px, 42vw);
+  height: auto;
+  opacity: 0.12;
+  pointer-events: none;
+  filter: saturate(0.9);
 }
 
 .actions {
@@ -133,6 +151,13 @@ code {
   .hero {
     padding: 28px 22px;
     border-radius: 26px;
+  }
+
+  .hero-watermark {
+    right: -52px;
+    bottom: -72px;
+    width: min(300px, 58vw);
+    opacity: 0.14;
   }
 
   .grid {


### PR DESCRIPTION
Use the supplied Magnetio logo and wordmark across the static site hero, add a watermark treatment, and update the repository README so GitHub shows the same branding.