### PR TITLE
Roll up dependency bumps and automate future updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,35 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: /addon
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      addon-minor-patch:
+        update-types:
+          - minor
+          - patch
+      addon-major:
+        update-types:
+          - major
 
   - package-ecosystem: npm
     directory: /scraper
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      scraper-minor-patch:
+        update-types:
+          - minor
+          - patch
+      scraper-major:
+        update-types:
+          - major

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,29 @@
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review "$PR_URL" --approve --body "Auto-approved: ${{ steps.meta.outputs.update-type }}"
+          gh pr merge "$PR_URL" --auto --squash

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -22,6 +22,6 @@ jobs:
           fetch-depth: 0
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,9 +25,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/addon/package-lock.json
+++ b/addon/package-lock.json
@@ -12,15 +12,15 @@
         "@keyv/redis": "^5.1.6",
         "axios": "^1.17.0",
         "cron": "^3.1.6",
-        "dotenv": "^16.3.1",
+        "dotenv": "^17.4.2",
         "express": "^4.18.2",
         "express-rate-limit": "^8.5.2",
         "keyv": "^5.6.0",
         "magnet-uri": "^6.0.1",
         "node-fetch": "^3.3.2",
-        "p-limit": "^5.0.0",
-        "p-queue": "^7.4.1",
-        "prom-client": "^14.2.0",
+        "p-limit": "^7.3.0",
+        "p-queue": "^9.3.0",
+        "prom-client": "^15.1.3",
         "redis": "^6.0.0",
         "stremio-addon-sdk": "^1.6.10",
         "swagger-stats": "^0.99.7",
@@ -76,6 +76,15 @@
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
       "license": "MIT"
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/@redis/client": {
       "version": "5.12.1",
@@ -683,9 +692,9 @@
       "license": "MIT"
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -1797,43 +1806,43 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
-      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
       "license": "MIT",
       "dependencies": {
-        "yocto-queue": "^1.0.0"
+        "yocto-queue": "^1.2.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-queue": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
-      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
       "license": "MIT",
       "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "p-timeout": "^5.0.2"
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-timeout": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
-      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1868,15 +1877,16 @@
       }
     },
     "node_modules/prom-client": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
-      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
         "tdigest": "^0.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^16 || ^18 || >=20"
       }
     },
     "node_modules/proxy-addr": {

--- a/addon/package.json
+++ b/addon/package.json
@@ -15,15 +15,15 @@
     "@keyv/redis": "^5.1.6",
     "axios": "^1.17.0",
     "cron": "^3.1.6",
-    "dotenv": "^16.3.1",
+    "dotenv": "^17.4.2",
     "express": "^4.18.2",
     "express-rate-limit": "^8.5.2",
     "keyv": "^5.6.0",
     "magnet-uri": "^6.0.1",
     "node-fetch": "^3.3.2",
-    "p-limit": "^5.0.0",
-    "p-queue": "^7.4.1",
-    "prom-client": "^14.2.0",
+    "p-limit": "^7.3.0",
+    "p-queue": "^9.3.0",
+    "prom-client": "^15.1.3",
     "redis": "^6.0.0",
     "stremio-addon-sdk": "^1.6.10",
     "swagger-stats": "^0.99.7",
@@ -32,6 +32,11 @@
   },
   "devDependencies": {
     "nodemon": "^3.0.2"
+  },
+  "overrides": {
+    "swagger-stats": {
+      "prom-client": "$prom-client"
+    }
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Summary
- Apply the 8 open Dependabot PRs (#68–#75) in one tested change: prom-client 14→15, p-limit 5→7, p-queue 7→9, dotenv 16→17, configure-pages 5→6, upload-pages-artifact 3→5, deploy-pages 4→5, gitleaks-action 2→3.
- Add `overrides` in addon/package.json so swagger-stats accepts prom-client v15 (its declared peer-dep range \`>= 10 <= 14\` is stale; the package works fine with v15).
- Add `.github/workflows/dependabot-auto-merge.yml` — approves + squash-merges patch/minor Dependabot PRs once CI is green; majors stay open for review.
- Update `.github/dependabot.yml` to group weekly bumps per ecosystem (one PR for github-actions, one PR each for addon/scraper minor+patch and major) so future updates don't fan out into many PRs.

## Test plan
- [x] \`npm ci\` succeeds in /addon against the bumped lockfile
- [x] \`npm test\` in /addon — 16/16 pass
- [ ] CI \`validate\` job green on this PR
- [ ] Close PRs #68–#75 as superseded once this lands
- [ ] After merge, verify next Dependabot run produces grouped PRs

Generated with Claude Code