### PR TITLE
Free port 7000 before recreating addon container

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,6 +108,8 @@ jobs:
             echo "Created .env from .env.example. Update it on the server before exposing the addon publicly."
           fi
 
+          docker compose stop addon || true
+          docker compose rm -f addon || true
           docker compose up -d --build --remove-orphans
           docker compose ps
 


### PR DESCRIPTION
## Summary
- Stops and removes the addon service before \`docker compose up\` so the previous container releases its port binding before the new one tries to bind on 7000
- Unblocks the deploy workflow which has been failing with \`bind: address already in use\` on the addon container

## Test plan
- [ ] CI \`validate\` passes
- [ ] After merge, deploy job completes and addon serves on the public URL

Generated with Claude Code