### PR TITLE
Stop magnetio_addon by raw name and log port-7000 owners

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,8 +108,13 @@ jobs:
             echo "Created .env from .env.example. Update it on the server before exposing the addon publicly."
           fi
 
-          docker compose stop addon || true
-          docker compose rm -f addon || true
+          echo "--- Containers publishing port 7000 (before) ---"
+          docker ps -a --filter "publish=7000" --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' || true
+
+          docker stop magnetio_addon 2>/dev/null || true
+          docker rm -f magnetio_addon 2>/dev/null || true
+          docker compose rm -f addon 2>/dev/null || true
+
           docker compose up -d --build --remove-orphans
           docker compose ps
 


### PR DESCRIPTION
## Summary
- The first port-fix only ran \`docker compose stop addon\`, which doesn't catch an orphaned container named \`magnetio_addon\` that isn't tracked by the current compose project (e.g. from a previous project rename)
- Stops/removes the container by its raw name as well, then runs the existing \`compose up\`
- Adds a diagnostic listing every container currently publishing port 7000 so we can see what's holding it if the bind still fails

## Test plan
- [ ] CI \`validate\` passes
- [ ] After merge, deploy job completes and addon serves on the public URL
- [ ] Logs show the prior \`magnetio_addon\` container being removed before \`compose up\`

Generated with Claude Code