### PR TITLE
Fix scraper 429 rotation, add Debrid catalog toggle, document HTTPS/Oracle setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ https://your-server:7000/providers=yts,eztv,1337x|sort=qualityseeders|limit=10|R
 | `torznabKey` | API key | - | Torznab API key |
 | `prewarm` | `1`, `0`, `true`, `false` | `1` | Background-add top uncached torrents to debrid |
 | `prewarmLimit` | `0` to `10` | `3` | How many uncached results to prewarm per service |
+| `debridCatalogs` | `1`, `0`, `true`, `false` | `1` | Expose debrid cloud catalogs (Movies/Series) when a key is set |
 | `excludeSizes` | Size thresholds like `1GB,2GB` | None | Exclude streams below these sizes |
 | `maxSize` | Bytes | None | Maximum file size |
 | `RD` | API key | - | Real-Debrid |
@@ -517,13 +518,50 @@ The workflow runs on a self-hosted GitHub Actions runner. Push to `main` trigger
 
 ### Exposing to the Internet
 
-Stremio requires HTTPS for addon URLs. Common approaches:
+Stremio's clients (web, desktop, mobile) refuse to install an addon over plain `http://`. This is a Stremio-side restriction, not something the addon can opt out of. If you can hit the configure page on `http://YOUR_IP:7000/configure` but Stremio fails to install, HTTPS is almost always the reason.
 
-- **Cloudflare Tunnel** or **Cloudflare DNS proxy** pointing to your server
-- **Nginx reverse proxy** with Let's Encrypt SSL
-- **Tailscale** or **WireGuard** for private access
+The fix is to put any HTTPS-terminating reverse proxy in front of the addon. The `ADDON_PUBLIC_URL` env var controls the base URL that appears inside manifests; the landing page uses `location.origin` so it picks up your public domain automatically when accessed through the proxy.
 
-The `ADDON_PUBLIC_URL` environment variable controls what base URL appears in manifests. The landing page uses `location.origin` which automatically resolves to your public domain when accessed through it.
+#### Caddy (recommended, auto Let's Encrypt)
+
+```caddyfile
+magnetio.example.com {
+  reverse_proxy localhost:7000
+}
+```
+
+Caddy handles the certificate, the renewals, and HTTP-to-HTTPS redirect by itself. One file, restart, done.
+
+#### Cloudflare Tunnel (no open ports)
+
+```bash
+cloudflared tunnel create magnetio
+cloudflared tunnel route dns magnetio magnetio.example.com
+cloudflared tunnel run --url http://localhost:7000 magnetio
+```
+
+Useful when you don't want to open inbound ports on your firewall at all.
+
+#### Nginx + certbot, Tailscale, WireGuard
+
+Also fine. Anything that gives the addon a real `https://` URL on a public domain works.
+
+#### Oracle Cloud / Free Tier VPS notes
+
+Oracle's free-tier VMs block inbound traffic in **two** places by default. If you set up the addon, `:7000` works locally on the box, but install from Stremio (or even `curl` from your laptop) fails, you almost certainly need to open both:
+
+1. **VCN security list** (web console): add an ingress rule for TCP `443` (and `7000` if you're testing without a proxy), source `0.0.0.0/0`.
+2. **Host iptables** (Oracle Linux ships a strict default):
+
+   ```bash
+   sudo iptables -I INPUT 6 -p tcp --dport 443 -j ACCEPT
+   sudo iptables -I INPUT 6 -p tcp --dport 7000 -j ACCEPT
+   sudo netfilter-persistent save   # or: sudo service iptables save
+   ```
+
+   On Ubuntu images use `ufw allow 443/tcp` and `ufw allow 7000/tcp` instead.
+
+Combined with the HTTPS step above, that's enough to install Magnetio on an Oracle VPS.
 
 ---
 
@@ -559,6 +597,12 @@ The `ADDON_PUBLIC_URL` environment variable controls what base URL appears in ma
 | `PREWARM_CRON` | `0 4 * * *` | Cron schedule for prewarm job |
 | `PREWARM_MOVIES` | `50` | Number of top movies to prewarm |
 | `PREWARM_SERIES` | `20` | Number of top series to prewarm |
+| `SCRAPER_PROVIDER_TIMEOUT_MS` | `25000` | Per-provider timeout (raise if slow providers keep firing `timed out`) |
+| `SCRAPER_HARD_TIMEOUT_MS` | `provider + 2000` | Overall scrape budget |
+| `SCRAPER_EARLY_RETURN_MS` | `6000` | Return early once enough results land |
+| `SCRAPER_MIN_EARLY_RESULTS` | `10` | Minimum results before early return kicks in |
+| `SCRAPER_DOMAIN_COOLDOWN_MS` | `300000` | Cooldown when a domain returns 403/5xx/timeout |
+| `SCRAPER_RATELIMIT_COOLDOWN_MS` | `600000` | Longer cooldown when a domain returns 429 |
 | `LOG_LEVEL` | `info` | Winston log level |
 
 ### Optional Services

--- a/README.md
+++ b/README.md
@@ -518,6 +518,8 @@ The workflow runs on a self-hosted GitHub Actions runner. Push to `main` trigger
 
 ### Exposing to the Internet
 
+> **Don't want to self-host?** There's a public hosted instance at [magnetio.peterdsp.dev](https://magnetio.peterdsp.dev) (configure and install at [magnetio.peterdsp.dev/configure](https://magnetio.peterdsp.dev/configure)). Your Debrid keys still stay between your browser and your Debrid provider, the manifest URL just points at the hosted addon. The rest of this section is only relevant if you're running your own instance on a VPS or home server.
+
 Stremio's clients (web, desktop, mobile) refuse to install an addon over plain `http://`. This is a Stremio-side restriction, not something the addon can opt out of. If you can hit the configure page on `http://YOUR_IP:7000/configure` but Stremio fails to install, HTTPS is almost always the reason.
 
 The fix is to put any HTTPS-terminating reverse proxy in front of the addon. The `ADDON_PUBLIC_URL` env var controls the base URL that appears inside manifests; the landing page uses `location.origin` so it picks up your public domain automatically when accessed through the proxy.

--- a/addon/lib/configuration.js
+++ b/addon/lib/configuration.js
@@ -104,6 +104,9 @@ export function parseConfiguration(configString) {
       case 'prewarm':
         config.prewarmDebrid = parseBoolean(value, config.prewarmDebrid);
         break;
+      case 'debridcatalogs':
+        config.debridCatalogs = parseBoolean(value, config.debridCatalogs);
+        break;
       case 'prewarmlimit':
         config.prewarmLimit = clampPrewarmLimit(parseInt(value, 10), config.prewarmLimit);
         break;
@@ -186,6 +189,7 @@ export function getDefaultConfiguration() {
     subtitleLanguages:  ['en'],       // subtitle preference defaults to English
     prewarmDebrid:      true,         // warm a few top uncached results in debrid
     prewarmLimit:       3,
+    debridCatalogs:     true,         // expose debrid cloud catalogs when a key is set
     excludeSizes:       [],
     maxSize:            null,
     // Recommendations (TMDB)

--- a/addon/lib/landingTemplate.js
+++ b/addon/lib/landingTemplate.js
@@ -60,6 +60,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
     subtitleLanguages: initialConfig.subtitleLanguages ?? ['en'],
     prewarmDebrid: initialConfig.prewarmDebrid ?? true,
     prewarmLimit: initialConfig.prewarmLimit ?? 3,
+    debridCatalogs: initialConfig.debridCatalogs ?? true,
     tmdbApiKey: initialConfig.tmdbApiKey ?? '',
     torznabUrl: initialConfig.torznabUrl ?? '',
     torznabApiKey: initialConfig.torznabApiKey ?? '',
@@ -1128,6 +1129,13 @@ export function landingTemplate(manifest, initialConfig = {}) {
             <option value="5">5</option>
           </select>
         </label>
+        <label>
+          Add Debrid cloud catalogs
+          <select id="debridCatalogs" title="When a Debrid API key is set, also expose your cloud catalog (Movies/Series) in Stremio">
+            <option value="1">Enabled</option>
+            <option value="0">Disabled</option>
+          </select>
+        </label>
       </div>
       <div class="field-grid">
         ${DEBRID_FIELDS.map(([id, label, url]) => `
@@ -1240,6 +1248,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
       document.getElementById('limit').value = String(initialConfig.limit || 10);
       document.getElementById('prewarm').value = initialConfig.prewarmDebrid === false ? '0' : '1';
       document.getElementById('prewarmLimit').value = String(initialConfig.prewarmLimit || 3);
+      document.getElementById('debridCatalogs').value = initialConfig.debridCatalogs === false ? '0' : '1';
 
       setChipGrid('qualities', initialConfig.qualities || []);
       setChipGrid('languages', initialConfig.languages || []);
@@ -1266,6 +1275,8 @@ export function landingTemplate(manifest, initialConfig = {}) {
       parts.push('limit=' + document.getElementById('limit').value);
       parts.push('prewarm=' + document.getElementById('prewarm').value);
       parts.push('prewarmLimit=' + document.getElementById('prewarmLimit').value);
+      var debridCatalogsValue = document.getElementById('debridCatalogs').value;
+      if (debridCatalogsValue === '0') parts.push('debridCatalogs=0');
 
       var qualities = selectedValues('qualities');
       var languages = selectedValues('languages');

--- a/addon/lib/manifest.js
+++ b/addon/lib/manifest.js
@@ -82,14 +82,17 @@ function getDescription(config) {
 }
 
 function getCatalogs(config) {
-  const debridCatalogs = getEnabledMochs(config).flatMap(moch =>
-    moch.hasCatalog
-      ? [
-          { id: `${moch.id}_movie`,  type: 'movie',  name: `${moch.name} - Movies`  },
-          { id: `${moch.id}_series`, type: 'series', name: `${moch.name} - Series` },
-        ]
-      : []
-  );
+  const debridCatalogsEnabled = config?.debridCatalogs !== false;
+  const debridCatalogs = debridCatalogsEnabled
+    ? getEnabledMochs(config).flatMap(moch =>
+        moch.hasCatalog
+          ? [
+              { id: `${moch.id}_movie`,  type: 'movie',  name: `${moch.name} - Movies`  },
+              { id: `${moch.id}_series`, type: 'series', name: `${moch.name} - Series` },
+            ]
+          : []
+      )
+    : [];
 
   const similarCatalogs = config?.tmdbApiKey
     ? [

--- a/scraper/lib/domainRotation.js
+++ b/scraper/lib/domainRotation.js
@@ -1,24 +1,39 @@
 import { logger } from './logger.js';
 
 const domainHealth = new Map();
-const COOLDOWN_MS = 5 * 60 * 1000;
+const DEFAULT_COOLDOWN_MS    = 5 * 60 * 1000;
+const DEFAULT_RATELIMIT_MS   = 10 * 60 * 1000;
+const COOLDOWN_MS  = parseInt(process.env.SCRAPER_DOMAIN_COOLDOWN_MS  ?? String(DEFAULT_COOLDOWN_MS),  10);
+const RATELIMIT_MS = parseInt(process.env.SCRAPER_RATELIMIT_COOLDOWN_MS ?? String(DEFAULT_RATELIMIT_MS), 10);
+
+function cooldownFor(reason) {
+  return reason === 'ratelimited' ? RATELIMIT_MS : COOLDOWN_MS;
+}
 
 function isHealthy(domain) {
   const entry = domainHealth.get(domain);
   if (!entry) return true;
-  if (Date.now() - entry.failedAt > COOLDOWN_MS) {
+  if (Date.now() - entry.failedAt > cooldownFor(entry.reason)) {
     domainHealth.delete(domain);
     return true;
   }
   return false;
 }
 
-function markFailed(domain) {
-  domainHealth.set(domain, { failedAt: Date.now() });
+function markFailed(domain, reason) {
+  domainHealth.set(domain, { failedAt: Date.now(), reason });
 }
 
 function markHealthy(domain) {
   domainHealth.delete(domain);
+}
+
+function classifyError(status) {
+  if (status === 429) return 'ratelimited';
+  if (status === 403) return 'blocked';
+  if (!status) return 'network';
+  if (status >= 500) return 'server';
+  return null;
 }
 
 export async function tryDomains(domains, requestFn, providerName) {
@@ -32,10 +47,10 @@ export async function tryDomains(domains, requestFn, providerName) {
       return result;
     } catch (err) {
       const status = err.response?.status;
-      const isBadDomain = !status || status >= 500 || status === 403;
-      if (isBadDomain) {
-        markFailed(domain);
-        logger.debug(`[${providerName}] domain ${domain} failed (${status ?? err.code ?? err.message}), trying next`);
+      const reason = classifyError(status);
+      if (reason) {
+        markFailed(domain, reason);
+        logger.debug(`[${providerName}] domain ${domain} ${reason} (${status ?? err.code ?? err.message}), trying next`);
       } else {
         throw err;
       }

--- a/scraper/providers/index.js
+++ b/scraper/providers/index.js
@@ -54,9 +54,10 @@ const ALL_PROVIDERS = [
 
 // Max 6 providers running simultaneously (up from 4 for faster throughput)
 const limit = pLimit(6);
-const PROVIDER_TIMEOUT_MS = 15_000;
-const EARLY_RETURN_MS     = 5_000;   // Return results after 5s if we have enough
-const MIN_EARLY_RESULTS   = 10;      // Minimum results before early return kicks in
+const PROVIDER_TIMEOUT_MS = parseInt(process.env.SCRAPER_PROVIDER_TIMEOUT_MS ?? '25000', 10);
+const HARD_TIMEOUT_MS     = parseInt(process.env.SCRAPER_HARD_TIMEOUT_MS     ?? String(PROVIDER_TIMEOUT_MS + 2000), 10);
+const EARLY_RETURN_MS     = parseInt(process.env.SCRAPER_EARLY_RETURN_MS     ?? '6000', 10);
+const MIN_EARLY_RESULTS   = parseInt(process.env.SCRAPER_MIN_EARLY_RESULTS   ?? '10', 10);
 
 /**
  * Scrape all (or a subset of) providers for a given content item.
@@ -102,13 +103,13 @@ export async function scrapeAll(type, meta, providerIds = null, context = {}) {
       }
     }, EARLY_RETURN_MS);
 
-    // Hard deadline: never wait longer than PROVIDER_TIMEOUT_MS
+    // Hard deadline: cut off after HARD_TIMEOUT_MS even if providers are still pending
     const hardTimer = setTimeout(() => {
       if (!resolved) {
-        logger.info(`Hard timeout: ${collected.length} results from ${completedCount}/${providers.length} providers after ${PROVIDER_TIMEOUT_MS}ms`);
+        logger.info(`Hard timeout: ${collected.length} results from ${completedCount}/${providers.length} providers after ${HARD_TIMEOUT_MS}ms`);
         finalize();
       }
-    }, PROVIDER_TIMEOUT_MS);
+    }, HARD_TIMEOUT_MS);
 
     // Launch all providers in parallel (concurrency-limited)
     const tasks = providers.map(p =>


### PR DESCRIPTION
Closes #63, closes #64, closes #65, closes #66.

## What changed

### Scraper resilience (#65)
- Rotate domains on HTTP 429. Before this, 429 was treated as a hard error and bubbled up immediately, so a single rate-limited domain would knock the whole provider out instead of trying the next domain. That matches the "0 results, all domains exhausted" pattern in the issue logs.
- Separate, longer cooldown when a domain is rate-limited (10 min default) vs hard-failed (5 min default).
- Per-provider timeout raised from 15s to 25s, and the overall scrape budget is now `provider + 2s` so per-provider timeouts fire cleanly before the hard cutoff.
- All windows are env-tunable: `SCRAPER_PROVIDER_TIMEOUT_MS`, `SCRAPER_HARD_TIMEOUT_MS`, `SCRAPER_EARLY_RETURN_MS`, `SCRAPER_MIN_EARLY_RESULTS`, `SCRAPER_DOMAIN_COOLDOWN_MS`, `SCRAPER_RATELIMIT_COOLDOWN_MS`.

### Debrid catalog opt-out (#64)
- New `debridCatalogs` config flag, default `true` so existing users see no change.
- Configure page has a new "Add Debrid cloud catalogs" toggle inside the Debrid Services card.
- When the flag is off, `manifest.catalogs` skips the Debrid Movies/Series catalogs even if a key is set.

### Deployment docs (#63, #66)
- Rewrote "Exposing to the Internet" with a why-HTTPS-is-needed note plus working Caddy and Cloudflare Tunnel snippets.
- New "Oracle Cloud / Free Tier VPS notes" subsection covering both VCN security list rules and the host iptables config.
- Documented the new scraper env vars and the `debridCatalogs` param.

## Test plan
- [x] `cd addon && npm test` (30/30 pass)
- [x] Module smoke test on `scraper/lib/domainRotation.js` and `scraper/providers/index.js`
- [ ] Deploy auto-runs on merge via the self-hosted runner; verify the addon comes up and `/manifest.json` is reachable

Generated with Claude Code