### PR TITLE
Add P2P privacy proxy, per-user VPN, speed optimizations, and reliability

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install addon dependencies
         working-directory: addon
-        run: npm ci
+        run: npm install --ignore-scripts=false
 
       - name: Test addon
         working-directory: addon

--- a/addon/.env.example
+++ b/addon/.env.example
@@ -38,6 +38,13 @@ OPENSUBTITLES_PASSWORD=
 # SUBTITLE_SYNC_MAX_OFFSET_SECONDS=300
 # ALASS_SPLIT_PENALTY=10
 
+# ─── P2P Privacy Proxy ───────────────────────────────────────────────────────
+# Route torrent traffic through a SOCKS5 proxy (e.g. VPN) to hide server IP.
+# TORRENT_PROXY=socks5://127.0.0.1:1080
+
+# Max concurrent torrent engines (each uses ~15-30 MB RAM).
+# PROXY_MAX_ENGINES=3
+
 # ─── Debrid API Keys (set in user configuration, not here) ────────────────────
 # These are passed per-user in the addon configuration URL.
 # Do NOT set them here unless running a single-user private instance.

--- a/addon/Dockerfile
+++ b/addon/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update \
     python3-pip \
     wget \
     ca-certificates \
+    build-essential \
+    python3-setuptools \
   && python3 -m pip install --no-cache-dir --break-system-packages ffsubsync \
   && rm -rf /var/lib/apt/lists/*
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -2,6 +2,7 @@ import express from 'express';
 import swaggerStats from 'swagger-stats';
 import { serverless } from './serverless.js';
 import { initBestTrackers } from './lib/magnetHelper.js';
+import { destroyAllEngines } from './lib/torrentProxy.js';
 import { logger } from './lib/logger.js';
 
 const app = express();
@@ -27,10 +28,24 @@ app.use('/', serverless);
 
 const PORT = process.env.PORT || 7000;
 
-app.listen(PORT, async () => {
-  logger.info(`Magnetio addon running on port ${PORT}`);
+async function start() {
   await initBestTrackers();
   logger.info('Best trackers initialized');
-});
+
+  const server = app.listen(PORT, () => {
+    logger.info(`Magnetio addon running on port ${PORT}`);
+  });
+
+  const shutdown = () => {
+    logger.info('Shutting down…');
+    destroyAllEngines();
+    server.close(() => process.exit(0));
+    setTimeout(() => process.exit(1), 10_000);
+  };
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+}
+
+start();
 
 export default app;

--- a/addon/lib/cache.js
+++ b/addon/lib/cache.js
@@ -21,22 +21,45 @@ function getStore() {
   return _store;
 }
 
+const _inflight = new Map();
+
 /**
- * Fetch from cache; call loader on miss and store the result.
+ * Fetch from cache with stale-while-revalidate semantics.
  *
- * @param {string}   key
- * @param {Function} loader    async () => value
- * @param {number}   ttl       TTL in seconds
+ * - Fresh hit (within TTL): return immediately.
+ * - Stale hit (past TTL but within 2x TTL): return stale data, refresh in background.
+ * - Miss: block on loader.
+ *
+ * Stored format: { data, createdAt }
  */
 export async function cacheWrap(key, loader, ttl = 3600) {
   const store = getStore();
-  const cached = await store.get(key);
-  if (cached !== undefined) return cached;
+  const ttlMs = ttl * 1000;
+  const entry = await store.get(key);
+
+  if (entry?.data !== undefined && entry.createdAt) {
+    const age = Date.now() - entry.createdAt;
+    if (age < ttlMs) return entry.data;
+
+    if (!_inflight.has(key)) {
+      const refresh = loader()
+        .then(value => {
+          const isEmpty = Array.isArray(value) && value.length === 0;
+          if (!isEmpty) {
+            return store.set(key, { data: value, createdAt: Date.now() }, ttlMs * 2);
+          }
+        })
+        .catch(err => logger.warn(`SWR refresh failed [${key}]: ${err.message}`))
+        .finally(() => _inflight.delete(key));
+      _inflight.set(key, refresh);
+    }
+    return entry.data;
+  }
 
   const value = await loader();
   const isEmpty = Array.isArray(value) && value.length === 0;
   if (!isEmpty) {
-    await store.set(key, value, ttl * 1000); // Keyv uses milliseconds
+    await store.set(key, { data: value, createdAt: Date.now() }, ttlMs * 2);
   }
   return value;
 }

--- a/addon/lib/configuration.js
+++ b/addon/lib/configuration.js
@@ -152,6 +152,9 @@ export function parseConfiguration(configString) {
         try { config.torznabApiKey = decodeURIComponent(value); }
         catch { config.torznabApiKey = value; }
         break;
+      case 'proxy':
+        config.proxyStreams = parseBoolean(value, config.proxyStreams);
+        break;
     }
   }
 
@@ -197,6 +200,8 @@ export function getDefaultConfiguration() {
     // Torznab (Jackett / Prowlarr)
     torznabUrl:         null,
     torznabApiKey:      null,
+    // P2P privacy proxy
+    proxyStreams:        false,
     // Debrid keys (all null by default)
     realDebridApiKey:   null,
     premiumizeApiKey:   null,

--- a/addon/lib/configuration.js
+++ b/addon/lib/configuration.js
@@ -155,6 +155,10 @@ export function parseConfiguration(configString) {
       case 'proxy':
         config.proxyStreams = parseBoolean(value, config.proxyStreams);
         break;
+      case 'proxyurl':
+        try { config.proxyUrl = decodeURIComponent(value); }
+        catch { config.proxyUrl = value; }
+        break;
     }
   }
 
@@ -202,6 +206,7 @@ export function getDefaultConfiguration() {
     torznabApiKey:      null,
     // P2P privacy proxy
     proxyStreams:        false,
+    proxyUrl:            null,
     // Debrid keys (all null by default)
     realDebridApiKey:   null,
     premiumizeApiKey:   null,

--- a/addon/lib/landingTemplate.js
+++ b/addon/lib/landingTemplate.js
@@ -1114,6 +1114,20 @@ export function landingTemplate(manifest, initialConfig = {}) {
     </div>
 
     <div class="config-card">
+      <div class="config-card-title">Privacy Proxy</div>
+      <div class="config-card-desc">Stream torrents through the server instead of connecting directly to the swarm. Your IP address is never exposed to peers or trackers. Requires ADDON_PUBLIC_URL to be set on the server.</div>
+      <div class="field-grid">
+        <label>
+          P2P Privacy Proxy
+          <select id="proxyStreams">
+            <option value="0">Disabled</option>
+            <option value="1">Enabled</option>
+          </select>
+        </label>
+      </div>
+    </div>
+
+    <div class="config-card">
       <div class="config-card-title">Debrid Services</div>
       <div class="config-card-desc">Add API keys for your debrid services. Cached torrents resolve as direct streams automatically.</div>
       <div class="field-grid">
@@ -1253,6 +1267,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
       document.getElementById('prewarm').value = initialConfig.prewarmDebrid === false ? '0' : '1';
       document.getElementById('prewarmLimit').value = String(initialConfig.prewarmLimit || 3);
       document.getElementById('debridCatalogs').value = initialConfig.debridCatalogs === false ? '0' : '1';
+      document.getElementById('proxyStreams').value = initialConfig.proxyStreams ? '1' : '0';
 
       setChipGrid('qualities', initialConfig.qualities || []);
       setChipGrid('languages', initialConfig.languages || []);
@@ -1281,6 +1296,8 @@ export function landingTemplate(manifest, initialConfig = {}) {
       parts.push('prewarmLimit=' + document.getElementById('prewarmLimit').value);
       var debridCatalogsValue = document.getElementById('debridCatalogs').value;
       if (debridCatalogsValue === '0') parts.push('debridCatalogs=0');
+      var proxyValue = document.getElementById('proxyStreams').value;
+      if (proxyValue === '1') parts.push('proxy=1');
 
       var qualities = selectedValues('qualities');
       var languages = selectedValues('languages');

--- a/addon/lib/landingTemplate.js
+++ b/addon/lib/landingTemplate.js
@@ -68,6 +68,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
     tmdbApiKey: initialConfig.tmdbApiKey ?? '',
     torznabUrl: initialConfig.torznabUrl ?? '',
     torznabApiKey: initialConfig.torznabApiKey ?? '',
+    proxyUrl: initialConfig.proxyUrl ?? '',
     realDebridApiKey: initialConfig.realDebridApiKey ?? '',
     premiumizeApiKey: initialConfig.premiumizeApiKey ?? '',
     allDebridApiKey: initialConfig.allDebridApiKey ?? '',
@@ -1113,9 +1114,14 @@ export function landingTemplate(manifest, initialConfig = {}) {
       </div>
     </div>
 
+    <div class="config-card" id="p2pWarningCard" style="display:none;border-color:rgba(251,191,36,0.4);">
+      <div class="config-card-title" style="color:#fbbf24;">&#9888; P2P Exposure Warning</div>
+      <div class="config-card-desc" style="color:#fbbf24;opacity:0.85;">You have no debrid service configured. Without a debrid service, streams are fetched directly via P2P (peer-to-peer), which <strong>exposes your IP address</strong> to other peers in the torrent swarm. To protect your privacy, either add a debrid API key above or enable the Privacy Proxy below and provide your own VPN/SOCKS5 proxy so that the Magnetio server routes torrent traffic through your VPN.</div>
+    </div>
+
     <div class="config-card">
       <div class="config-card-title">Privacy Proxy</div>
-      <div class="config-card-desc">Stream torrents through the server instead of connecting directly to the swarm. Your IP address is never exposed to peers or trackers. Requires ADDON_PUBLIC_URL to be set on the server.</div>
+      <div class="config-card-desc">Stream torrents through the Magnetio server instead of connecting directly to the swarm. Your device never touches the torrent network.<br /><br /><strong>Important:</strong> Without a VPN/SOCKS5 proxy configured below, the server's own IP is used for torrent connections. Each user can provide their own SOCKS5 proxy (from a VPN provider) so that all torrent traffic is routed through that VPN — keeping both you and the server operator private.</div>
       <div class="field-grid">
         <label>
           P2P Privacy Proxy
@@ -1124,7 +1130,15 @@ export function landingTemplate(manifest, initialConfig = {}) {
             <option value="1">Enabled</option>
           </select>
         </label>
+        <label id="proxyUrlLabel" style="display:none;">
+          Your SOCKS5 Proxy
+          <div class="password-wrap">
+            <input type="password" id="proxyUrl" autocomplete="off" placeholder="socks5://user:pass@host:1080" />
+            <button type="button" class="eye-toggle" data-target="proxyUrl" title="Toggle visibility">${SVG_EYE}</button>
+          </div>
+        </label>
       </div>
+      <div class="config-card-desc" id="proxyHelpText" style="display:none;font-size:0.8rem;opacity:0.7;">Most VPN providers offer SOCKS5 proxy access (NordVPN, Surfshark, PIA, Mullvad, etc.). Enter the SOCKS5 address from your VPN provider above. This way, torrent traffic goes through your VPN — not through the server's IP.</div>
     </div>
 
     <div class="config-card">
@@ -1268,6 +1282,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
       document.getElementById('prewarmLimit').value = String(initialConfig.prewarmLimit || 3);
       document.getElementById('debridCatalogs').value = initialConfig.debridCatalogs === false ? '0' : '1';
       document.getElementById('proxyStreams').value = initialConfig.proxyStreams ? '1' : '0';
+      document.getElementById('proxyUrl').value = initialConfig.proxyUrl || '';
 
       setChipGrid('qualities', initialConfig.qualities || []);
       setChipGrid('languages', initialConfig.languages || []);
@@ -1298,6 +1313,8 @@ export function landingTemplate(manifest, initialConfig = {}) {
       if (debridCatalogsValue === '0') parts.push('debridCatalogs=0');
       var proxyValue = document.getElementById('proxyStreams').value;
       if (proxyValue === '1') parts.push('proxy=1');
+      var proxyUrlVal = document.getElementById('proxyUrl').value.trim();
+      if (proxyUrlVal) parts.push('proxyUrl=' + encodeURIComponent(proxyUrlVal));
 
       var qualities = selectedValues('qualities');
       var languages = selectedValues('languages');
@@ -1391,7 +1408,31 @@ export function landingTemplate(manifest, initialConfig = {}) {
       observer.observe(section);
     });
 
+    function updateProxyVisibility() {
+      var enabled = document.getElementById('proxyStreams').value === '1';
+      document.getElementById('proxyUrlLabel').style.display = enabled ? '' : 'none';
+      document.getElementById('proxyHelpText').style.display = enabled ? '' : 'none';
+    }
+
+    function updateP2pWarning() {
+      var keys = ['rd','pm','ad','dl','ed','oc','tb','pu'];
+      var hasDebrid = keys.some(function(id) { return document.getElementById(id).value.trim(); });
+      document.getElementById('p2pWarningCard').style.display = hasDebrid ? 'none' : '';
+    }
+
+    document.getElementById('proxyStreams').addEventListener('change', function() {
+      updateProxyVisibility();
+      refreshPreview();
+    });
+
+    var keys_for_warning = ['rd','pm','ad','dl','ed','oc','tb','pu'];
+    keys_for_warning.forEach(function(id) {
+      document.getElementById(id).addEventListener('input', updateP2pWarning);
+    });
+
     applyInitialState();
+    updateProxyVisibility();
+    updateP2pWarning();
     refreshPreview();
   </script>
 </body>

--- a/addon/lib/landingTemplate.js
+++ b/addon/lib/landingTemplate.js
@@ -924,7 +924,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
         <span class="gradient-text">Stream anything.</span><br />Own your setup.
       </h1>
       <p class="hero-sub">
-        Magnetio is a self-hosted Stremio addon that aggregates torrents from 22+ providers,
+        Magnetio is a self-hosted addon for <strong>Stremio</strong> and <strong><a href="https://nuvioplugin.com" target="_blank" rel="noreferrer" style="color:var(--accent);text-decoration:none;">Nuvio</a></strong> that aggregates torrents from 22+ providers,
         resolves them through 8 debrid services, and delivers instant high-quality streams.
       </p>
       <div class="hero-buttons">
@@ -989,6 +989,11 @@ export function landingTemplate(manifest, initialConfig = {}) {
         <span class="feature-icon">&#128274;</span>
         <div class="feature-title">Self-Hosted</div>
         <div class="feature-desc">Runs on a Raspberry Pi. Your API keys never leave your server. No tracking, no telemetry.</div>
+      </div>
+      <div class="feature-card">
+        <span class="feature-icon">&#128257;</span>
+        <div class="feature-title">Stremio + Nuvio</div>
+        <div class="feature-desc">Works with both <a href="https://www.stremio.com" target="_blank" rel="noreferrer" style="color:var(--accent);">Stremio</a> and <a href="https://nuvioplugin.com" target="_blank" rel="noreferrer" style="color:var(--accent);">Nuvio</a>. Same manifest URL, same configuration — install once, use on both platforms.</div>
       </div>
     </div>
   </section>

--- a/addon/lib/repository.js
+++ b/addon/lib/repository.js
@@ -3,7 +3,7 @@ import { cacheWrap } from './cache.js';
 import { logger } from './logger.js';
 
 const SCRAPER_BASE_URL = process.env.SCRAPER_URL || 'http://localhost:8080';
-const REQUEST_TIMEOUT  = 30_000;
+const REQUEST_TIMEOUT  = 20_000;
 
 function simpleHash(str) {
   let h = 0;
@@ -32,18 +32,27 @@ export async function getStreams(type, id, config) {
   const cacheKey = `streams:${type}:${id}:${providerKey}${torznabSuffix}`;
 
   return cacheWrap(cacheKey, async () => {
-    try {
-      const params = { providers: config.providers?.join(',') };
-      if (config.torznabUrl) {
-        params.torznabUrl = config.torznabUrl;
-        params.torznabApiKey = config.torznabApiKey || '';
-      }
+    const params = { providers: config.providers?.join(',') };
+    if (config.torznabUrl) {
+      params.torznabUrl = config.torznabUrl;
+      params.torznabApiKey = config.torznabApiKey || '';
+    }
 
+    const fetchOnce = async () => {
       const { data } = await axios.get(`${SCRAPER_BASE_URL}/streams/${type}/${id}`, {
         timeout: REQUEST_TIMEOUT,
         params,
       });
       return Array.isArray(data.streams) ? data.streams : [];
+    };
+
+    try {
+      const results = await fetchOnce();
+      if (results.length === 0) {
+        await new Promise(r => setTimeout(r, 1000));
+        return fetchOnce();
+      }
+      return results;
     } catch (err) {
       logger.warn(`Repository fetch failed [${id}]: ${err.message}`);
       return [];

--- a/addon/lib/streamInfo.js
+++ b/addon/lib/streamInfo.js
@@ -42,9 +42,13 @@ export function toStreamInfo(record, config) {
   };
 
   if (useProxy) {
-    stream.url = `${baseUrl}/proxy/stream/${record.infoHash}/${fileIdx ?? 0}`;
+    const proxyParams = config.proxyUrl
+      ? `?p=${encodeURIComponent(Buffer.from(config.proxyUrl).toString('base64url'))}`
+      : '';
+    stream.url = `${baseUrl}/proxy/stream/${record.infoHash}/${fileIdx ?? 0}${proxyParams}`;
     stream.behaviorHints.notWebReady = true;
-    const proxyDesc = description + '\n🛡️ Privacy Proxy';
+    const proxyLabel = config.proxyUrl ? '🛡️ VPN Proxy' : '🛡️ Privacy Proxy';
+    const proxyDesc = description + '\n' + proxyLabel;
     stream.title = proxyDesc;
     stream.description = proxyDesc;
   } else {

--- a/addon/lib/streamInfo.js
+++ b/addon/lib/streamInfo.js
@@ -4,6 +4,10 @@ import { extractQuality } from './sort.js';
 
 const ADDON_PREFIX = '⚡ Magnetio';
 
+function getPublicBaseUrl(config) {
+  return (config?._publicBaseUrl || process.env.ADDON_PUBLIC_URL || '').replace(/\/$/, '');
+}
+
 /**
  * Convert a raw torrent record into a Stremio stream object.
  */
@@ -22,19 +26,32 @@ export function toStreamInfo(record, config) {
     [seedersStr, sizeStr].filter(Boolean).join(' '),
   ].filter(Boolean).join('\n');
 
+  const baseUrl = getPublicBaseUrl(config);
+  const useProxy = config?.proxyStreams && baseUrl;
+  const fileIdx = record.fileIdx ?? undefined;
+
   const stream = {
     name,
     title: description,
     description,
-    infoHash:  record.infoHash,
-    fileIdx:   record.fileIdx ?? 0,
-    sources:   buildSources(record),
     behaviorHints: {
       bingeGroup:      getBingeGroup(record, quality),
       filename:        filename || undefined,
       videoSize:       record.size || undefined,
     },
   };
+
+  if (useProxy) {
+    stream.url = `${baseUrl}/proxy/stream/${record.infoHash}/${fileIdx ?? 0}`;
+    stream.behaviorHints.notWebReady = true;
+    const proxyDesc = description + '\n🛡️ Privacy Proxy';
+    stream.title = proxyDesc;
+    stream.description = proxyDesc;
+  } else {
+    stream.infoHash = record.infoHash;
+    stream.fileIdx = fileIdx;
+    stream.sources = buildSources(record);
+  }
 
   if (record.subtitles?.length) {
     stream.subtitles = enrichSubtitles(record.subtitles);

--- a/addon/lib/torrentProxy.js
+++ b/addon/lib/torrentProxy.js
@@ -1,0 +1,166 @@
+import torrentStream from 'torrent-stream';
+import { logger } from './logger.js';
+import path from 'path';
+
+const MAX_ENGINES = parseInt(process.env.PROXY_MAX_ENGINES ?? '3', 10);
+const IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+const DOWNLOAD_PATH = process.env.PROXY_DOWNLOAD_PATH || '/tmp/magnetio-torrents';
+const PROXY_SOCKS = process.env.TORRENT_PROXY || null;
+
+const engines = new Map();
+
+function buildMagnet(infoHash, trackers = []) {
+  let uri = `magnet:?xt=urn:btih:${infoHash}`;
+  for (const t of trackers) uri += `&tr=${encodeURIComponent(t)}`;
+  return uri;
+}
+
+function buildEngineOpts() {
+  const opts = { path: DOWNLOAD_PATH, connections: 30, uploads: 0, verify: false };
+  if (PROXY_SOCKS) {
+    const url = new URL(PROXY_SOCKS);
+    opts.tracker = {
+      proxy: { host: url.hostname, port: parseInt(url.port, 10) || 1080 },
+    };
+  }
+  return opts;
+}
+
+function getOrCreateEngine(infoHash, trackers) {
+  const existing = engines.get(infoHash);
+  if (existing) {
+    existing.lastAccess = Date.now();
+    return existing;
+  }
+
+  while (engines.size >= MAX_ENGINES) {
+    let oldest = null;
+    for (const [key, entry] of engines) {
+      if (!oldest || entry.lastAccess < oldest.lastAccess) oldest = { key, entry };
+    }
+    if (oldest) destroyEngine(oldest.key);
+  }
+
+  const magnet = buildMagnet(infoHash, trackers);
+  const engine = torrentStream(magnet, buildEngineOpts());
+
+  const entry = {
+    engine,
+    ready: false,
+    readyPromise: null,
+    lastAccess: Date.now(),
+    idleTimer: null,
+  };
+
+  entry.readyPromise = new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error('Engine timeout')), 60_000);
+    engine.on('ready', () => {
+      clearTimeout(timeout);
+      entry.ready = true;
+      resolve();
+    });
+    engine.on('error', (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+
+  resetIdleTimer(infoHash, entry);
+  engines.set(infoHash, entry);
+  logger.info(`Torrent engine started: ${infoHash} (${engines.size}/${MAX_ENGINES})`);
+  return entry;
+}
+
+function resetIdleTimer(infoHash, entry) {
+  if (entry.idleTimer) clearTimeout(entry.idleTimer);
+  entry.idleTimer = setTimeout(() => destroyEngine(infoHash), IDLE_TIMEOUT_MS);
+}
+
+function destroyEngine(infoHash) {
+  const entry = engines.get(infoHash);
+  if (!entry) return;
+  if (entry.idleTimer) clearTimeout(entry.idleTimer);
+  try { entry.engine.destroy(); } catch {}
+  engines.delete(infoHash);
+  logger.info(`Torrent engine destroyed: ${infoHash} (${engines.size}/${MAX_ENGINES})`);
+}
+
+function selectFile(engine, fileIdx) {
+  const files = engine.files.sort((a, b) => b.length - a.length);
+  if (fileIdx != null && fileIdx < engine.files.length) {
+    return engine.files[fileIdx];
+  }
+  const videoExts = ['.mp4', '.mkv', '.avi', '.m4v', '.webm', '.mov'];
+  const video = files.find(f => videoExts.includes(path.extname(f.name).toLowerCase()));
+  return video || files[0];
+}
+
+export async function streamTorrent(infoHash, fileIdx, req, res) {
+  const entry = getOrCreateEngine(infoHash, []);
+  try {
+    await entry.readyPromise;
+  } catch (err) {
+    destroyEngine(infoHash);
+    res.status(504).json({ error: 'Torrent engine failed to start' });
+    return;
+  }
+
+  entry.lastAccess = Date.now();
+  resetIdleTimer(infoHash, entry);
+
+  const file = selectFile(entry.engine, fileIdx);
+  if (!file) {
+    res.status(404).json({ error: 'No suitable file found in torrent' });
+    return;
+  }
+
+  const ext = path.extname(file.name).toLowerCase();
+  const mimeMap = {
+    '.mp4': 'video/mp4', '.mkv': 'video/x-matroska', '.avi': 'video/x-msvideo',
+    '.m4v': 'video/mp4', '.webm': 'video/webm', '.mov': 'video/quicktime',
+  };
+  const contentType = mimeMap[ext] || 'application/octet-stream';
+  const total = file.length;
+
+  const range = req.headers.range;
+  if (range) {
+    const parts = range.replace(/bytes=/, '').split('-');
+    const start = parseInt(parts[0], 10);
+    const end = parts[1] ? parseInt(parts[1], 10) : total - 1;
+    const chunkSize = end - start + 1;
+
+    res.writeHead(206, {
+      'Content-Range': `bytes ${start}-${end}/${total}`,
+      'Accept-Ranges': 'bytes',
+      'Content-Length': chunkSize,
+      'Content-Type': contentType,
+    });
+
+    const stream = file.createReadStream({ start, end });
+    stream.pipe(res);
+    stream.on('error', () => res.end());
+  } else {
+    res.writeHead(200, {
+      'Content-Length': total,
+      'Content-Type': contentType,
+      'Accept-Ranges': 'bytes',
+    });
+
+    const stream = file.createReadStream();
+    stream.pipe(res);
+    stream.on('error', () => res.end());
+  }
+
+  res.on('close', () => {
+    entry.lastAccess = Date.now();
+    resetIdleTimer(infoHash, entry);
+  });
+}
+
+export function destroyAllEngines() {
+  for (const key of [...engines.keys()]) destroyEngine(key);
+}
+
+export function getEngineCount() {
+  return engines.size;
+}

--- a/addon/lib/torrentProxy.js
+++ b/addon/lib/torrentProxy.js
@@ -1,8 +1,9 @@
 import torrentStream from 'torrent-stream';
 import { logger } from './logger.js';
+import { getBestTrackers } from './magnetHelper.js';
 import path from 'path';
 
-const MAX_ENGINES = parseInt(process.env.PROXY_MAX_ENGINES ?? '3', 10);
+const MAX_ENGINES = Math.max(1, parseInt(process.env.PROXY_MAX_ENGINES ?? '3', 10) || 3);
 const IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 const DOWNLOAD_PATH = process.env.PROXY_DOWNLOAD_PATH || '/tmp/magnetio-torrents';
 const PROXY_SOCKS = process.env.TORRENT_PROXY || null;
@@ -90,17 +91,17 @@ function destroyEngine(infoHash) {
 }
 
 function selectFile(engine, fileIdx) {
-  const files = engine.files.sort((a, b) => b.length - a.length);
   if (fileIdx != null && fileIdx < engine.files.length) {
     return engine.files[fileIdx];
   }
+  const files = [...engine.files].sort((a, b) => b.length - a.length);
   const videoExts = ['.mp4', '.mkv', '.avi', '.m4v', '.webm', '.mov'];
   const video = files.find(f => videoExts.includes(path.extname(f.name).toLowerCase()));
   return video || files[0];
 }
 
 export async function streamTorrent(infoHash, fileIdx, req, res, proxyUrl) {
-  const { entry, engineKey } = getOrCreateEngine(infoHash, [], proxyUrl);
+  const { entry, engineKey } = getOrCreateEngine(infoHash, getBestTrackers(), proxyUrl);
   try {
     await entry.readyPromise;
   } catch (err) {
@@ -129,8 +130,15 @@ export async function streamTorrent(infoHash, fileIdx, req, res, proxyUrl) {
   const range = req.headers.range;
   if (range) {
     const parts = range.replace(/bytes=/, '').split('-');
-    const start = parseInt(parts[0], 10);
+    const start = parseInt(parts[0], 10) || 0;
     const end = parts[1] ? parseInt(parts[1], 10) : total - 1;
+
+    if (start >= total || end >= total || start > end || start < 0) {
+      res.writeHead(416, { 'Content-Range': `bytes */${total}` });
+      res.end();
+      return;
+    }
+
     const chunkSize = end - start + 1;
 
     res.writeHead(206, {

--- a/addon/lib/torrentProxy.js
+++ b/addon/lib/torrentProxy.js
@@ -15,22 +15,26 @@ function buildMagnet(infoHash, trackers = []) {
   return uri;
 }
 
-function buildEngineOpts() {
+function buildEngineOpts(proxyUrl) {
   const opts = { path: DOWNLOAD_PATH, connections: 30, uploads: 0, verify: false };
-  if (PROXY_SOCKS) {
-    const url = new URL(PROXY_SOCKS);
-    opts.tracker = {
-      proxy: { host: url.hostname, port: parseInt(url.port, 10) || 1080 },
-    };
+  const socks = proxyUrl || PROXY_SOCKS;
+  if (socks) {
+    try {
+      const url = new URL(socks);
+      opts.tracker = {
+        proxy: { host: url.hostname, port: parseInt(url.port, 10) || 1080 },
+      };
+    } catch {}
   }
   return opts;
 }
 
-function getOrCreateEngine(infoHash, trackers) {
-  const existing = engines.get(infoHash);
+function getOrCreateEngine(infoHash, trackers, proxyUrl) {
+  const engineKey = proxyUrl ? `${infoHash}:${proxyUrl}` : infoHash;
+  const existing = engines.get(engineKey);
   if (existing) {
     existing.lastAccess = Date.now();
-    return existing;
+    return { entry: existing, engineKey };
   }
 
   while (engines.size >= MAX_ENGINES) {
@@ -42,7 +46,7 @@ function getOrCreateEngine(infoHash, trackers) {
   }
 
   const magnet = buildMagnet(infoHash, trackers);
-  const engine = torrentStream(magnet, buildEngineOpts());
+  const engine = torrentStream(magnet, buildEngineOpts(proxyUrl));
 
   const entry = {
     engine,
@@ -65,10 +69,10 @@ function getOrCreateEngine(infoHash, trackers) {
     });
   });
 
-  resetIdleTimer(infoHash, entry);
-  engines.set(infoHash, entry);
+  resetIdleTimer(engineKey, entry);
+  engines.set(engineKey, entry);
   logger.info(`Torrent engine started: ${infoHash} (${engines.size}/${MAX_ENGINES})`);
-  return entry;
+  return { entry, engineKey };
 }
 
 function resetIdleTimer(infoHash, entry) {
@@ -95,18 +99,18 @@ function selectFile(engine, fileIdx) {
   return video || files[0];
 }
 
-export async function streamTorrent(infoHash, fileIdx, req, res) {
-  const entry = getOrCreateEngine(infoHash, []);
+export async function streamTorrent(infoHash, fileIdx, req, res, proxyUrl) {
+  const { entry, engineKey } = getOrCreateEngine(infoHash, [], proxyUrl);
   try {
     await entry.readyPromise;
   } catch (err) {
-    destroyEngine(infoHash);
+    destroyEngine(engineKey);
     res.status(504).json({ error: 'Torrent engine failed to start' });
     return;
   }
 
   entry.lastAccess = Date.now();
-  resetIdleTimer(infoHash, entry);
+  resetIdleTimer(engineKey, entry);
 
   const file = selectFile(entry.engine, fileIdx);
   if (!file) {
@@ -153,7 +157,7 @@ export async function streamTorrent(infoHash, fileIdx, req, res) {
 
   res.on('close', () => {
     entry.lastAccess = Date.now();
-    resetIdleTimer(infoHash, entry);
+    resetIdleTimer(engineKey, entry);
   });
 }
 

--- a/addon/lib/translatedSubtitles.js
+++ b/addon/lib/translatedSubtitles.js
@@ -11,7 +11,6 @@ const MAX_INPUT_BYTES = 768 * 1024;
 const MAX_BATCH_CHARS = 4000;
 const TRANSLATION_SEPARATOR = '\n\n@@~~@@\n\n';
 const SOURCE_LANGUAGE = 'en';
-const TARGET_LANGUAGES = ['el'];
 const MAX_TRANSLATIONS = 2;
 
 const BLOCKED_HOSTNAMES = new Set([
@@ -27,7 +26,8 @@ const HTTP_HEADERS = {
 
 export function attachTranslatedSubtitles(subtitles, config) {
   const languages = resolveSubtitleLanguages(config);
-  const target = TARGET_LANGUAGES.find(code => languages.includes(code));
+  const nonEnglish = languages.filter(code => code !== SOURCE_LANGUAGE);
+  const target = nonEnglish[0];
   if (!target) return subtitles;
 
   const baseUrl = String(config?._publicBaseUrl || '').replace(/\/$/, '');

--- a/addon/moch/alldebrid.js
+++ b/addon/moch/alldebrid.js
@@ -4,7 +4,6 @@ import { logger } from '../lib/logger.js';
 
 const AD_BASE  = 'https://api.alldebrid.com/v4';
 const APP_NAME = 'magnetio';
-const SERVICE  = 'AD';
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 

--- a/addon/moch/debridlink.js
+++ b/addon/moch/debridlink.js
@@ -3,7 +3,6 @@ import { isValidToken, blacklistToken, selectVideoFile, resolveWithCache } from 
 import { logger } from '../lib/logger.js';
 
 const DL_BASE = 'https://debrid-link.com/api/v2';
-const SERVICE  = 'DL';
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 

--- a/addon/moch/easydebrid.js
+++ b/addon/moch/easydebrid.js
@@ -3,7 +3,6 @@ import { isValidToken, blacklistToken, resolveWithCache } from './mochHelper.js'
 import { logger } from '../lib/logger.js';
 
 const ED_BASE = 'https://easydebrid.com/api/v1';
-const SERVICE  = 'ED';
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 

--- a/addon/moch/offcloud.js
+++ b/addon/moch/offcloud.js
@@ -3,7 +3,6 @@ import { isValidToken, blacklistToken, selectVideoFile, resolveWithCache } from 
 import { logger } from '../lib/logger.js';
 
 const OC_BASE = 'https://offcloud.com/api';
-const SERVICE  = 'OC';
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 

--- a/addon/moch/premiumize.js
+++ b/addon/moch/premiumize.js
@@ -3,7 +3,6 @@ import { isValidToken, blacklistToken, selectVideoFile, resolveWithCache } from 
 import { logger } from '../lib/logger.js';
 
 const PM_BASE = 'https://www.premiumize.me/api';
-const SERVICE  = 'PM';
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 

--- a/addon/moch/putio.js
+++ b/addon/moch/putio.js
@@ -3,7 +3,6 @@ import { isValidToken, blacklistToken, selectVideoFile, resolveWithCache } from 
 import { logger } from '../lib/logger.js';
 
 const PU_BASE = 'https://api.put.io/v2';
-const SERVICE  = 'PU';
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 

--- a/addon/moch/realdebrid.js
+++ b/addon/moch/realdebrid.js
@@ -4,7 +4,6 @@ import { logger } from '../lib/logger.js';
 import { getClientIp } from '../lib/requestContext.js';
 
 const RD_BASE = 'https://api.real-debrid.com/rest/1.0';
-const SERVICE  = 'RD';
 
 // RealDebrid error codes that indicate the token is no longer valid
 const AUTH_ERROR_CODES = new Set([8, 9, 20]);
@@ -239,12 +238,6 @@ function handleRdError(err, apiKey) {
 }
 
 // ─── Utils ────────────────────────────────────────────────────────────────────
-
-function chunkArray(arr, size) {
-  const chunks = [];
-  for (let i = 0; i < arr.length; i += size) chunks.push(arr.slice(i, i + size));
-  return chunks;
-}
 
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));

--- a/addon/moch/torbox.js
+++ b/addon/moch/torbox.js
@@ -3,7 +3,6 @@ import { isValidToken, blacklistToken, selectVideoFile, resolveWithCache } from 
 import { logger } from '../lib/logger.js';
 
 const TB_BASE = 'https://api.torbox.app/v1/api';
-const SERVICE  = 'TB';
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 

--- a/addon/package-lock.json
+++ b/addon/package-lock.json
@@ -24,6 +24,7 @@
         "redis": "^6.2.0",
         "stremio-addon-sdk": "^1.6.10",
         "swagger-stats": "^0.99.7",
+        "torrent-stream": "^1.2.1",
         "ua-parser-js": "^2.0.10",
         "winston": "^3.11.0"
       },
@@ -182,6 +183,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/addr-to-ip-port": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/addr-to-ip-port/-/addr-to-ip-port-1.5.4.tgz",
+      "integrity": "sha512-ByxmJgv8vjmDcl3IDToxL2yrWFrRtFpZAToY0f46XFXl8zS081t7El5MXIodwm7RC6DhHBRoOSMLFSPKCtHukg==",
+      "license": "MIT"
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -319,6 +326,12 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/bencode": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/bencode/-/bencode-0.7.0.tgz",
+      "integrity": "sha512-MG5AM/hkQIZoz/layZ1JK3xBTfqkLcJ3dJ7u2lx+6vZT1JWyK3OgEFGx1WFzWt6grGH6OSGQvRcCnhWKLp4f1Q==",
+      "license": "MIT"
+    },
     "node_modules/bep53-range": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/bep53-range/-/bep53-range-2.0.1.tgz",
@@ -346,6 +359,74 @@
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
       "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
       "license": "MIT"
+    },
+    "node_modules/bitfield": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bitfield/-/bitfield-0.1.0.tgz",
+      "integrity": "sha512-M15ypXCxXd81FSOWL2ejHpB1TDKmz7Y55/VuqfExJi72sHW0JzE5dfV+hrSZafZtWRg/tdMsdte5dgwrlOM7nA==",
+      "license": "-"
+    },
+    "node_modules/bittorrent-dht": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-6.4.2.tgz",
+      "integrity": "sha512-DeBunF1nL/ckThYyU3AVtHFR195zNV06Ob6bKNXA1y6X56GSKMfkNCABB45YcbZevGMW1dytFlm59D/fws5lTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bencode": "^0.7.0",
+        "buffer-equals": "^1.0.3",
+        "debug": "^2.2.0",
+        "inherits": "^2.0.1",
+        "k-bucket": "^0.6.0",
+        "k-rpc": "^3.6.0",
+        "lru": "^2.0.0"
+      }
+    },
+    "node_modules/bittorrent-tracker": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/bittorrent-tracker/-/bittorrent-tracker-7.7.0.tgz",
+      "integrity": "sha512-YFgPTVRhUMncZr8tM3ige7gnViMGhKoGF23qaiISRG8xtYebTGHrMSMXsTXo6O1KbtdEI+4jzvGY1K/wdT9GUA==",
+      "license": "MIT",
+      "dependencies": {
+        "bencode": "^0.8.0",
+        "bn.js": "^4.4.0",
+        "compact2string": "^1.2.0",
+        "debug": "^2.0.0",
+        "hat": "0.0.3",
+        "inherits": "^2.0.1",
+        "ip": "^1.0.1",
+        "minimist": "^1.1.1",
+        "once": "^1.3.0",
+        "random-iterate": "^1.0.1",
+        "run-parallel": "^1.1.2",
+        "run-series": "^1.0.2",
+        "simple-get": "^2.0.0",
+        "simple-peer": "^6.0.0",
+        "simple-websocket": "^4.0.0",
+        "string2compact": "^1.1.1",
+        "uniq": "^1.0.1",
+        "ws": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "bittorrent-tracker": "bin/cmd.js"
+      }
+    },
+    "node_modules/bittorrent-tracker/node_modules/bencode": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/bencode/-/bencode-0.8.0.tgz",
+      "integrity": "sha512-MWs3FqaWOGg5l+quIT9JTx7+SlcMbfPqqpWy+GOYi5rjZkX8i03tkNhAQn3pD2GAKENPpP3ScUR97ZUMffhHZA==",
+      "license": "MIT"
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
+    },
+    "node_modules/bncode": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/bncode/-/bncode-0.5.3.tgz",
+      "integrity": "sha512-0P5VuWobU5Gwbeio8n9Jsdv0tE1IikrV9n4f7RsnXHNtxmdd/oeIO6QyoSEUAEyo5P6i3XMfBppi82WqNsT4JA=="
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
@@ -424,16 +505,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -448,6 +529,52 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-equal": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/buffer-equals": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/buffer-equals/-/buffer-equals-1.0.4.tgz",
+      "integrity": "sha512-99MsCq0j5+RhubVEtKQgKaD6EM+UP3xJgIvQqwJ3SOLDUekzxMX1ylXBng+Wa2sh7mGT0W6RUly8ojjr1Tt6nA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -530,6 +657,62 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chrome-dgram": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/chrome-dgram/-/chrome-dgram-3.0.6.tgz",
+      "integrity": "sha512-bqBsUuaOiXiqxXt/zA/jukNJJ4oaOtc7ciwqJpZVEaaXwwxqgI2/ZdG02vXYWUhHGziDlvGMQWk0qObgJwVYKA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "run-series": "^1.1.9"
+      }
+    },
+    "node_modules/chrome-dns": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chrome-dns/-/chrome-dns-1.0.1.tgz",
+      "integrity": "sha512-HqsYJgIc8ljJJOqOzLphjAs79EUuWSX3nzZi2LNkzlw3GIzAeZbaSektC8iT/tKvLqZq8yl1GJu5o6doA4TRbg==",
+      "license": "MIT",
+      "dependencies": {
+        "chrome-net": "^3.3.2"
+      }
+    },
+    "node_modules/chrome-net": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/chrome-net/-/chrome-net-3.3.4.tgz",
+      "integrity": "sha512-Jzy2EnzmE+ligqIZUsmWnck9RBXLuUy6CaKyuNMtowFG3ZvLt8d+WBJCTPEludV0DHpIKjAOlwjFmTaEdfdWCw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1"
       }
     },
     "node_modules/cli-cursor": {
@@ -641,6 +824,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/compact2string": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/compact2string/-/compact2string-1.4.1.tgz",
+      "integrity": "sha512-3D+EY5nsRhqnOwDxveBv5T8wGo4DEvYxjDtPGmdOX+gfr5gE92c2RC0w2wa+xEefm07QuVqqcF3nZJUZ92l/og==",
+      "license": "BSD",
+      "dependencies": {
+        "ipaddr.js": ">= 0.1.5"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
     "node_modules/content-disposition": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
@@ -694,6 +892,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -728,6 +932,11 @@
         "url": "https://ko-fi.com/intcreator"
       }
     },
+    "node_modules/cyclist": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.1.1.tgz",
+      "integrity": "sha512-w8a8nQk9YSCkMmH2wDbFqpH1XMz7l409mSvWnnG6Iu6D0Ydhvq61XASE7QIaA46FxfG2Ag524ZuGgAy2cXPfsw=="
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -744,6 +953,18 @@
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/delayed-stream": {
@@ -841,6 +1062,24 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+      "integrity": "sha512-go5TQkd0YRXYhX+Lc3UrXkoKU5j+m72jEP5lHWr2Nh82L8wfZtH8toKgcg4T10o23ELIMGXQdwCbl+qAXIPDrw==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "~1.3.0"
+      }
+    },
+    "node_modules/end-of-stream/node_modules/once": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+      "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -915,6 +1154,15 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
     },
     "node_modules/express": {
       "version": "5.2.1",
@@ -1117,6 +1365,12 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fifo": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/fifo/-/fifo-0.1.4.tgz",
+      "integrity": "sha512-CpKgwraLo4YWY9cUEICNJ1WcOVR2WE1Jvot3Nvr7FGBiGOKgkn1CmF4zuCl9VxvEh1nQsdYXtQg+V0etPiED6g==",
+      "license": "MIT"
+    },
     "node_modules/figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -1185,6 +1439,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/flatten": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz",
+      "integrity": "sha512-pzNZh42/A2HmcRIpddSP0T+zBofd119o5rNB2u1YHv36CM2C/ietI2ZsjWZ2LSL7J0BNVkFn1a9Ad+cmO2lDQg==",
+      "deprecated": "flatten is deprecated in favor of utility frameworks such as lodash.",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/fn.name": {
       "version": "1.1.0",
@@ -1258,6 +1521,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-chunk-store": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/fs-chunk-store/-/fs-chunk-store-1.7.0.tgz",
+      "integrity": "sha512-KhjJmZAs2eqfhCb6PdPx4RcZtheGTz86tpTC5JTvqBn/xda+Nb+0C7dCyjOSN7T76H6a56LvH0SVXQMchLXDRw==",
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "^0.5.1",
+        "random-access-file": "^2.0.1",
+        "randombytes": "^2.0.3",
+        "rimraf": "^2.4.2",
+        "run-parallel": "^1.1.2",
+        "thunky": "^1.0.1"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1281,6 +1564,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/get-browser-rtc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.1.0.tgz",
+      "integrity": "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ==",
+      "license": "MIT"
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
@@ -1319,6 +1608,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -1330,6 +1640,34 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/gopd": {
@@ -1390,6 +1728,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hat": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz",
+      "integrity": "sha512-zpImx2GoKXy42fVDSEad2BPKuSQdLcqsCYa48K3zHSzM/ugWuYjLDr8IXxpVuL7uCLHw56eaiLxCRthhOzf5ug==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/hookified": {
@@ -1473,6 +1820,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/immediate-chunk-store": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/immediate-chunk-store/-/immediate-chunk-store-1.0.8.tgz",
+      "integrity": "sha512-0tQyTytUaIUskpv5j5L5ZeQuEjYDl9QIekwDUisdqpAM81OZjBaEIriW7hoiRLaLNxj1fXE8e1yx5JaCGrrE7A==",
+      "license": "MIT"
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1503,6 +1867,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
+      "license": "MIT"
+    },
     "node_modules/ip-address": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
@@ -1510,6 +1880,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/ip-set": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ip-set/-/ip-set-1.0.2.tgz",
+      "integrity": "sha512-Mb6kv78bTi4RNAIIWL8Bbre7hXOR2pNUi3j8FaQkLaitf/ZWxkq3/iIwXNYk2ACO3IMfdVdQrOkUtwZblO7uBA==",
+      "license": "MIT",
+      "dependencies": {
+        "ip": "^1.1.3"
       }
     },
     "node_modules/ipaddr.js": {
@@ -1623,6 +2002,61 @@
         "node": ">=4"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "license": "MIT"
+    },
+    "node_modules/k-bucket": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-0.6.0.tgz",
+      "integrity": "sha512-1zJpqkrLYgolqdO1TE1/FWf+mHfhJKLC2Wpi4JaMFZKi4b6tFEn9/d+JqscBIJw5auWFewp16CSAEetFGEC4NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal": "0.0.1",
+        "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/k-rpc": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/k-rpc/-/k-rpc-3.7.0.tgz",
+      "integrity": "sha512-XFL8PatIToQ/qhSSAq9FSK73wk4fX4DcHqjnkvSCrWC59PV02Oj1KeYa3KnREAXgA1DlCSzcKjk7M8usnT/dUw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equals": "^1.0.3",
+        "k-bucket": "^2.0.0",
+        "k-rpc-socket": "^1.5.0"
+      }
+    },
+    "node_modules/k-rpc-socket": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/k-rpc-socket/-/k-rpc-socket-1.11.1.tgz",
+      "integrity": "sha512-8xtA8oqbZ6v1Niryp2/g4GxW16EQh5MvrUylQoOG+zcrDff5CKttON2XUXvMwlIHq4/2zfPVFiinAccJ+WhxoA==",
+      "license": "MIT",
+      "dependencies": {
+        "bencode": "^2.0.0",
+        "chrome-dgram": "^3.0.2",
+        "chrome-dns": "^1.0.0",
+        "chrome-net": "^3.3.2"
+      }
+    },
+    "node_modules/k-rpc-socket/node_modules/bencode": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bencode/-/bencode-2.0.3.tgz",
+      "integrity": "sha512-D/vrAD4dLVX23NalHwb8dSvsUsxeRPO8Y7ToKA015JQYq69MLDOMkC0uGZYA/MPpltLO8rt8eqFC2j8DxjTZ/w==",
+      "license": "MIT"
+    },
+    "node_modules/k-rpc/node_modules/k-bucket": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-2.0.1.tgz",
+      "integrity": "sha512-Xuye90xBBDJJbvNSuy3z/Yl8ceVX02/sopqGUEwJkMgRw+//TQXx0/Hbgp60GsoVfZcCBllQXXp6AWe2INu8pw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal": "0.0.1",
+        "randombytes": "^2.0.3"
+      }
+    },
     "node_modules/keygrip": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
@@ -1678,6 +2112,18 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/lru": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lru/-/lru-2.0.1.tgz",
+      "integrity": "sha512-JGRd3IHM64MPsGVw1Mqbz2Y2HDIePqi/MLfPtdrkHQwvvJnSrS9b6gM3KS9PFR5xJnufXJczHHZSmGqfuII1ew==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/luxon": {
       "version": "3.7.2",
@@ -1797,6 +2243,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -1833,6 +2288,12 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/moment": {
       "version": "2.30.1",
@@ -2041,15 +2502,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-limit": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.1.tgz",
@@ -2093,6 +2545,44 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-torrent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/parse-torrent/-/parse-torrent-4.1.0.tgz",
+      "integrity": "sha512-FeoGe8bOYmSzxO31kYy44A03FjuULCMOIMom8KyuGvO8/lLVPJyo2nr9CwH/iYmNHm74hk7h70o59DOfk9Rq+A==",
+      "license": "MIT",
+      "dependencies": {
+        "magnet-uri": "^4.0.0",
+        "parse-torrent-file": "^2.0.0"
+      },
+      "bin": {
+        "parse-torrent": "bin/cmd.js"
+      }
+    },
+    "node_modules/parse-torrent-file": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/parse-torrent-file/-/parse-torrent-file-2.1.4.tgz",
+      "integrity": "sha512-u2MgLOjZPDDer1oRg1c+H/+54iIQYY5TKgQ5G8KrGLT1Dcwdo7Lj+QfQR123+u8J0AMSFGbQUvsBlSB7uIJcCA==",
+      "deprecated": "Use the parse-torrent package instead",
+      "license": "MIT",
+      "dependencies": {
+        "bencode": "^0.7.0",
+        "simple-sha1": "^2.0.0"
+      },
+      "bin": {
+        "parse-torrent-file": "bin/cmd.js"
+      }
+    },
+    "node_modules/parse-torrent/node_modules/magnet-uri": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/magnet-uri/-/magnet-uri-4.2.3.tgz",
+      "integrity": "sha512-aHhR49CRBOq3BX6jQOBdGMXhNT2+9LIH3CCIwHlR+aFE8nWMfBD1aNYxfm2u2LsCOwvfPeyCsdIg9KXSwdsOLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flatten": "0.0.1",
+        "thirty-two": "^0.0.2",
+        "xtend": "^4.0.0"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2100,6 +2590,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2110,6 +2609,55 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/peer-wire-protocol": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/peer-wire-protocol/-/peer-wire-protocol-0.7.1.tgz",
+      "integrity": "sha512-V9oTa/ZcfNNz9fAST28Gg0fXbPeFPk3SBImsYO8GDDG5D0E195vxXmjZ+SPrzr4BJyMQmdDmwUfTf9MZ62z4mw==",
+      "dependencies": {
+        "bitfield": "^0.1.0",
+        "bncode": "^0.2.3",
+        "buffer-alloc": "^1.1.0",
+        "buffer-from": "^1.0.0",
+        "readable-stream": "^1.0.2",
+        "speedometer": "^0.1.2"
+      }
+    },
+    "node_modules/peer-wire-protocol/node_modules/bncode": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/bncode/-/bncode-0.2.3.tgz",
+      "integrity": "sha512-IXGfySD68R/J2X/it8GZqAM+Vb3ByZvAlUi0Gysq4ZACq6hXGQ3YshKo0QS/f3S9wOWKjJnEjP6x3ELxqBnAOA=="
+    },
+    "node_modules/peer-wire-protocol/node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/peer-wire-protocol/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "license": "MIT"
+    },
+    "node_modules/peer-wire-swarm": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/peer-wire-swarm/-/peer-wire-swarm-0.12.2.tgz",
+      "integrity": "sha512-sIWZ1nTL9l6mI9J18kW1AeByBwagvNzGJlMmQA9pM+otKQtTIwnigK8SR0nEFrNZYqZelI6RQ6g4udvtQ2TI1g==",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "fifo": "^0.1.4",
+        "once": "^1.1.1",
+        "peer-wire-protocol": "^0.7.0",
+        "speedometer": "^0.1.2",
+        "utp": "0.0.7"
       }
     },
     "node_modules/picomatch": {
@@ -2124,6 +2672,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/prom-client": {
       "version": "15.1.3",
@@ -2182,6 +2736,68 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+      "license": "MIT"
+    },
+    "node_modules/random-access-file": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-2.2.1.tgz",
+      "integrity": "sha512-RGU0xmDqdOyEiynob1KYSeh8+9c9Td1MJ74GT1viMEYAn8SJ9oBtWCXLsYZukCF46yududHOdM449uRYbzBrZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp-classic": "^0.5.2",
+        "random-access-storage": "^1.1.1"
+      }
+    },
+    "node_modules/random-access-storage": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.4.3.tgz",
+      "integrity": "sha512-D5e2iIC5dNENWyBxsjhEnNOMCwZZ64TARK6dyMN+3g4OTC4MJxyjh9hKLjTGoNhDOPrgjI+YlFEHFnrp/cSnzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0",
+        "inherits": "^2.0.3",
+        "queue-tick": "^1.0.0"
+      }
+    },
+    "node_modules/random-iterate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/random-iterate/-/random-iterate-1.0.1.tgz",
+      "integrity": "sha512-Jdsdnezu913Ot8qgKgSgs63XkAjEsnMcS1z+cC6D6TNXsUXsMxy0RpclF2pzGZTEiTXL9BiArdGTEexcv4nqcA==",
+      "license": "MIT"
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -2221,6 +2837,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/re-emitter": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/re-emitter/-/re-emitter-1.1.4.tgz",
+      "integrity": "sha512-C0SIXdXDSus2yqqvV7qifnb4NoWP7mEBXJq3axci301mXHCZb8Djwm4hrEZo4UeXRaEnfjH98uQ8EBppk2oNWA==",
+      "license": "MIT"
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -2350,6 +2972,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
     "node_modules/router": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/router/-/router-1.3.8.tgz",
@@ -2375,9 +3010,9 @@
       "license": "MIT"
     },
     "node_modules/router/node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/run-async": {
@@ -2388,6 +3023,55 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/run-series": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.9.tgz",
+      "integrity": "sha512-Arc4hUN896vjkqCYrUXquBFtRZdv1PfLbTYP71efP6butxyQ0kWpiNJyAgsxscmQg1cqvHY32/UCBzXedTpU2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/rusha": {
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/rusha/-/rusha-0.8.14.tgz",
+      "integrity": "sha512-cLgakCUf6PedEu15t8kbsjnwIFFR2D4RfL+W3iWFJ4iac7z4B0ZI8fxy4R3J956kAI68HclCFGL8MPoUVC3qVA==",
+      "license": "MIT"
     },
     "node_modules/rxjs": {
       "version": "6.6.7",
@@ -2635,6 +3319,95 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.2.tgz",
+      "integrity": "sha512-Ijd/rV5o+mSBBs4F/x9oDPtTx9Zb6X9brmnXvMW4J7IR15ngi9q5xxqWBKU744jTZiaXtxaPL7uHG6vtN8kUkw==",
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-peer": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-6.4.4.tgz",
+      "integrity": "sha512-sY35UHankz0ba02Dd8YzdyXhEeTAnW6ZUyDfKOSwUht1GLp9VuMT4jQUXF/wG7C9vpwvitV7Ig7a6IkY/qizwg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^2.1.0",
+        "get-browser-rtc": "^1.0.0",
+        "inherits": "^2.0.1",
+        "randombytes": "^2.0.3",
+        "readable-stream": "^2.0.5"
+      }
+    },
+    "node_modules/simple-peer/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/simple-peer/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/simple-peer/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/simple-peer/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/simple-sha1": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-2.1.2.tgz",
+      "integrity": "sha512-TQl9rm4rdKAVmhO++sXAb8TNN0D6JAD5iyI1mqEPNpxUzTRrtm4aOG1pDf/5W/qCFihiaoK6uuL9rvQz1x1VKw==",
+      "license": "MIT",
+      "dependencies": {
+        "rusha": "^0.8.1"
+      }
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -2647,6 +3420,61 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/simple-websocket": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/simple-websocket/-/simple-websocket-4.3.1.tgz",
+      "integrity": "sha512-knEO6ub2Pw00c7ueOV6snKE1hr7jIdY068+239v0I8DVKofyd7IQmYHXrM9pZL1zuI0H7sd+Y5kedndBi5GXIA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^2.1.3",
+        "inherits": "^2.0.1",
+        "randombytes": "^2.0.3",
+        "readable-stream": "^2.0.5",
+        "ws": "^2.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "node_modules/simple-websocket/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/simple-websocket/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/simple-websocket/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/simple-websocket/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/speedometer": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
+      "integrity": "sha512-phdEoDlA6EUIVtzwq1UiNMXDUogczp204aYF/yfOhjNePWFfIpBJ1k5wLMuXQhEOOMjuTJEcc4vdZa+vuP+n/Q=="
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -2992,6 +3820,25 @@
         "node": ">=4"
       }
     },
+    "node_modules/string2compact": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/string2compact/-/string2compact-1.3.2.tgz",
+      "integrity": "sha512-3XUxUgwhj7Eqh2djae35QHZZT4mN3fsO7kagZhSGmhhlrQagVvWSFuuFIWnpxFS0CdTB2PlQcaL16RDi14I8uw==",
+      "license": "MIT",
+      "dependencies": {
+        "addr-to-ip-port": "^1.0.1",
+        "ipaddr.js": "^2.0.0"
+      }
+    },
+    "node_modules/string2compact/node_modules/ipaddr.js": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
+      "integrity": "sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -3091,9 +3938,9 @@
       "license": "MIT"
     },
     "node_modules/swagger-stats/node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -3153,22 +4000,33 @@
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
     },
+    "node_modules/thirty-two": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/thirty-two/-/thirty-two-0.0.2.tgz",
+      "integrity": "sha512-0j1A9eqbP8dSEtkqqEJGpYFN2lPgQR1d0qKS2KNAmIxkK6gV37D5hRa5b/mYzVL1fyAVWBkeUDIXybZdCLVBzA==",
+      "engines": {
+        "node": ">=0.2.6"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "license": "MIT"
     },
+    "node_modules/thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+      "license": "MIT"
+    },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {
@@ -3192,6 +4050,55 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/torrent-discovery": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/torrent-discovery/-/torrent-discovery-5.4.0.tgz",
+      "integrity": "sha512-bPTDIA7XEjRlw6vQyt7kM/h1mg1INBsibjbujISITonx4POENZgxfyCSEXZpDhbAkluSPH4HKRKs4/YTmNLC6w==",
+      "license": "MIT",
+      "dependencies": {
+        "bittorrent-dht": "^6.0.0",
+        "bittorrent-tracker": "^7.0.0",
+        "debug": "^2.0.0",
+        "inherits": "^2.0.1",
+        "re-emitter": "^1.0.0",
+        "run-parallel": "^1.1.2",
+        "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/torrent-piece": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/torrent-piece/-/torrent-piece-1.1.2.tgz",
+      "integrity": "sha512-ElXPyXKKG73o+uziHJ8qlYE9EuyDVxnK2zWL+pW/2bma7RsLpSwFFIJAb8Qui7/tel2hsHQW1z3zBnfQNREpWA==",
+      "license": "MIT"
+    },
+    "node_modules/torrent-stream": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/torrent-stream/-/torrent-stream-1.2.1.tgz",
+      "integrity": "sha512-F+3tYmXnpO2gyhZQ7o8yakELJH3FtKISI/FU0iWvchOWFUXiFnjbEBoumSzfcK1P71Qxzx2az4lVK4Dkq4KSew==",
+      "dependencies": {
+        "bitfield": "^0.1.0",
+        "bncode": "^0.5.2",
+        "buffer-from": "^1.0.0",
+        "end-of-stream": "^0.1.4",
+        "fs-chunk-store": "^1.3.0",
+        "hat": "0.0.3",
+        "immediate-chunk-store": "^1.0.5",
+        "ip-set": "^1.0.0",
+        "mkdirp": "^0.3.5",
+        "parse-torrent": "^4.0.0",
+        "peer-wire-swarm": "^0.12.0",
+        "rimraf": "^2.2.5",
+        "torrent-discovery": "^5.2.0",
+        "torrent-piece": "^1.0.0"
+      }
+    },
+    "node_modules/torrent-stream/node_modules/mkdirp": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha512-8OCq0De/h9ZxseqzCH8Kw/Filf5pF/vMI6+BH7Lu0jXz2pqYCjTAQRolSxRIi+Ax+oCCjlxoJMP0YQ4XlrQNHg==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "license": "MIT"
     },
     "node_modules/touch": {
       "version": "3.1.1",
@@ -3353,6 +4260,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==",
+      "license": "MIT"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -3377,17 +4290,25 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/utp": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/utp/-/utp-0.0.7.tgz",
+      "integrity": "sha512-2ZLjisH0HQkpqZTg2m7TK0Yn7TETTg7DxM0EpCKIIIV2ky9w9nSxW5a7gzdk4nH2h+pomrrGw0uywrUJfsm2eA==",
+      "dependencies": {
+        "cyclist": "~0.1.0"
+      }
+    },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {
@@ -3465,6 +4386,36 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "1.2.2",

--- a/addon/package-lock.json
+++ b/addon/package-lock.json
@@ -134,9 +134,9 @@
       }
     },
     "node_modules/@types/luxon": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
-      "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.3.tgz",
+      "integrity": "sha512-pE7BSbKHiojpl4v7iEzdfFLXXJaH5RPJxI3Wr4x3HU59l83PJfhcUx4mGPWq245+DCAENAzRF/+ZoYr2tJCe/g==",
       "license": "MIT"
     },
     "node_modules/@types/triple-beam": {
@@ -158,31 +158,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/accepts/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/accepts/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/addr-to-ip-port": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/addr-to-ip-port/-/addr-to-ip-port-1.5.4.tgz",
@@ -200,29 +175,6 @@
       "engines": {
         "node": ">= 6.0.0"
       }
-    },
-    "node_modules/agent-base/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/agent-base/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "3.2.0",
@@ -320,12 +272,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/basic-auth/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
     "node_modules/bencode": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/bencode/-/bencode-0.7.0.tgz",
@@ -381,6 +327,21 @@
         "lru": "^2.0.0"
       }
     },
+    "node_modules/bittorrent-dht/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/bittorrent-dht/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/bittorrent-tracker": {
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/bittorrent-tracker/-/bittorrent-tracker-7.7.0.tgz",
@@ -415,6 +376,21 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/bencode/-/bencode-0.8.0.tgz",
       "integrity": "sha512-MWs3FqaWOGg5l+quIT9JTx7+SlcMbfPqqpWy+GOYi5rjZkX8i03tkNhAQn3pD2GAKENPpP3ScUR97ZUMffhHZA==",
+      "license": "MIT"
+    },
+    "node_modules/bittorrent-tracker/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/bittorrent-tracker/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/bn.js": {
@@ -464,45 +440,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/body-parser/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/body-parser/node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/body-parser/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.9",
@@ -783,9 +720,9 @@
       }
     },
     "node_modules/color-string/node_modules/color-name": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
-      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+      "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20"
@@ -804,9 +741,9 @@
       }
     },
     "node_modules/color/node_modules/color-name": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
-      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+      "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20"
@@ -947,12 +884,20 @@
       }
     },
     "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decompress-response": {
@@ -1099,9 +1044,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -1208,9 +1153,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
-      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -1226,102 +1171,6 @@
         "express": ">= 4.11"
       }
     },
-    "node_modules/express-rate-limit/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/express-rate-limit/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/express/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/express/node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/express/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/express/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/express/node_modules/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -1334,6 +1183,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/external-editor/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/fecha": {
@@ -1417,29 +1278,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/finalhandler/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/finalhandler/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/flatten": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz",
@@ -1491,6 +1329,27 @@
         "node": ">= 6"
       }
     },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -1513,12 +1372,12 @@
       }
     },
     "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs-chunk-store": {
@@ -1778,39 +1637,20 @@
         "node": ">= 6"
       }
     },
-    "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/https-proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore-by-default": {
@@ -2107,12 +1947,6 @@
         "node": ">= 12.0.0"
       }
     },
-    "node_modules/logform/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/lru": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/lru/-/lru-2.0.1.tgz",
@@ -2172,12 +2006,16 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
@@ -2214,24 +2052,28 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
-        "mime-db": "1.52.0"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-fn": {
@@ -2253,13 +2095,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2305,9 +2147,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -2391,31 +2233,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/nodemon"
       }
-    },
-    "node_modules/nodemon/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/nodemon/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -2602,14 +2419,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
     },
     "node_modules/peer-wire-protocol": {
       "version": "0.7.1",
@@ -2628,24 +2441,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/bncode/-/bncode-0.2.3.tgz",
       "integrity": "sha512-IXGfySD68R/J2X/it8GZqAM+Vb3ByZvAlUi0Gysq4ZACq6hXGQ3YshKo0QS/f3S9wOWKjJnEjP6x3ELxqBnAOA=="
-    },
-    "node_modules/peer-wire-protocol/node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/peer-wire-protocol/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "license": "MIT"
     },
     "node_modules/peer-wire-swarm": {
       "version": "0.12.2",
@@ -2722,12 +2517,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -2799,12 +2595,16 @@
       }
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
@@ -2822,22 +2622,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/re-emitter": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/re-emitter/-/re-emitter-1.1.4.tgz",
@@ -2845,17 +2629,15 @@
       "license": "MIT"
     },
     "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
       "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
       }
     },
     "node_modules/readdirp": {
@@ -2986,34 +2768,20 @@
       }
     },
     "node_modules/router": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/router/-/router-1.3.8.tgz",
-      "integrity": "sha512-461UFH44NtSfIlS83PUg2N7OZo86BC/kB3dY77gJdsODsBhhw7+2uE0tzTINxrY9CahCUVk1VhpWCA5i1yoIEg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
       "dependencies": {
-        "array-flatten": "3.0.0",
-        "debug": "2.6.9",
-        "methods": "~1.1.2",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
-        "setprototypeof": "1.2.0",
-        "utils-merge": "1.0.1"
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18"
       }
-    },
-    "node_modules/router/node_modules/array-flatten": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
-      "license": "MIT"
-    },
-    "node_modules/router/node_modules/path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "license": "MIT"
     },
     "node_modules/run-async": {
       "version": "2.4.1",
@@ -3086,23 +2854,9 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/safe-stable-stringify": {
@@ -3121,9 +2875,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3159,63 +2913,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/send/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/send/node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/send/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/send/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/serve-static": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
@@ -3242,14 +2939,14 @@
       "license": "ISC"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -3363,10 +3060,25 @@
         "readable-stream": "^2.0.5"
       }
     },
+    "node_modules/simple-peer/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
     "node_modules/simple-peer/node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/simple-peer/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/simple-peer/node_modules/readable-stream": {
@@ -3383,12 +3095,6 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
-    },
-    "node_modules/simple-peer/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
     },
     "node_modules/simple-peer/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -3435,10 +3141,25 @@
         "xtend": "^4.0.1"
       }
     },
+    "node_modules/simple-websocket/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
     "node_modules/simple-websocket/node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/simple-websocket/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/simple-websocket/node_modules/readable-stream": {
@@ -3455,12 +3176,6 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
-    },
-    "node_modules/simple-websocket/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
     },
     "node_modules/simple-websocket/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -3587,6 +3302,21 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
+    "node_modules/stremio-addon-sdk/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/stremio-addon-sdk/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/stremio-addon-sdk/node_modules/express": {
       "version": "4.22.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
@@ -3651,6 +3381,27 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stremio-addon-sdk/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/stremio-addon-sdk/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/stremio-addon-sdk/node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -3669,11 +3420,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/stremio-addon-sdk/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
+    "node_modules/stremio-addon-sdk/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/stremio-addon-sdk/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/stremio-addon-sdk/node_modules/negotiator": {
       "version": "0.6.3",
@@ -3704,11 +3470,14 @@
         }
       }
     },
-    "node_modules/stremio-addon-sdk/node_modules/path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "license": "MIT"
+    "node_modules/stremio-addon-sdk/node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/stremio-addon-sdk/node_modules/raw-body": {
       "version": "2.5.3",
@@ -3724,6 +3493,50 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/stremio-addon-sdk/node_modules/router": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/router/-/router-1.3.8.tgz",
+      "integrity": "sha512-461UFH44NtSfIlS83PUg2N7OZo86BC/kB3dY77gJdsODsBhhw7+2uE0tzTINxrY9CahCUVk1VhpWCA5i1yoIEg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-flatten": "3.0.0",
+        "debug": "2.6.9",
+        "methods": "~1.1.2",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "setprototypeof": "1.2.0",
+        "utils-merge": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/stremio-addon-sdk/node_modules/router/node_modules/array-flatten": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
+      "license": "MIT"
+    },
+    "node_modules/stremio-addon-sdk/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/stremio-addon-sdk/node_modules/send": {
       "version": "0.19.2",
@@ -3778,13 +3591,10 @@
       }
     },
     "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "2.1.1",
@@ -3883,23 +3693,6 @@
         "prom-client": ">= 10 <= 14"
       }
     },
-    "node_modules/swagger-stats/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/swagger-stats/node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -3907,6 +3700,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/swagger-stats/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/swagger-stats/node_modules/http-errors": {
@@ -3925,17 +3727,20 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/swagger-stats/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/swagger-stats/node_modules/path-to-regexp": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "license": "MIT"
+    },
+    "node_modules/swagger-stats/node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/swagger-stats/node_modules/send": {
       "version": "0.19.0",
@@ -4066,6 +3871,21 @@
         "xtend": "^4.0.0"
       }
     },
+    "node_modules/torrent-discovery/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/torrent-discovery/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/torrent-piece": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/torrent-piece/-/torrent-piece-1.1.2.tgz",
@@ -4163,31 +3983,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/type-is/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/type-is/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
       "engines": {
         "node": ">=18"
       },
@@ -4379,6 +4174,92 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston-transport/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/winston-transport/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/winston/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/wrappy": {

--- a/addon/package.json
+++ b/addon/package.json
@@ -27,6 +27,7 @@
     "redis": "^6.2.0",
     "stremio-addon-sdk": "^1.6.10",
     "swagger-stats": "^0.99.7",
+    "torrent-stream": "^1.2.1",
     "ua-parser-js": "^2.0.10",
     "winston": "^3.11.0"
   },
@@ -35,7 +36,21 @@
   },
   "overrides": {
     "swagger-stats": {
-      "prom-client": "$prom-client"
+      "prom-client": "$prom-client",
+      "send": "0.19.0",
+      "uuid": "11.1.1"
+    },
+    "router@1": {
+      "path-to-regexp": "0.1.13"
+    },
+    "inquirer": {
+      "external-editor": {
+        "tmp": "0.2.7"
+      }
+    },
+    "torrent-stream": {
+      "ip": "2.0.1",
+      "ws": "8.21.2"
     }
   },
   "engines": {

--- a/addon/serverless.js
+++ b/addon/serverless.js
@@ -15,6 +15,7 @@ import { handleCommunitySubtitlesProxy } from './lib/communitySubtitles.js';
 import { handleTranslatedSubtitleProxy } from './lib/translatedSubtitles.js';
 import { trackRequest, getStats } from './lib/analytics.js';
 import { runWithClientIp } from './lib/requestContext.js';
+import { streamTorrent } from './lib/torrentProxy.js';
 
 const router = express.Router();
 
@@ -113,6 +114,19 @@ router.get('/proxy/yify/:id.srt', subtitleProxyLimiter, handleYifySubtitleProxy)
 router.get('/proxy/tvsubs/:id.srt', subtitleProxyLimiter, handleTvSubtitlesProxy);
 router.get('/proxy/community/:id.srt', subtitleProxyLimiter, handleCommunitySubtitlesProxy);
 router.get('/proxy/translated/:id.srt', subtitleProxyLimiter, handleTranslatedSubtitleProxy);
+
+router.get('/proxy/stream/:infoHash/:fileIdx', async (req, res) => {
+  const { infoHash, fileIdx } = req.params;
+  if (!/^[a-f0-9]{40}$/i.test(infoHash)) {
+    return res.status(400).json({ error: 'Invalid infoHash' });
+  }
+  try {
+    await streamTorrent(infoHash, parseInt(fileIdx, 10) || 0, req, res);
+  } catch (err) {
+    logger.error(`Proxy stream error: ${err.message}`);
+    if (!res.headersSent) res.status(500).json({ error: 'Stream failed' });
+  }
+});
 
 router.get('/health', (_req, res) => {
   res.json({ status: 'ok', service: 'Magnetio', version: '1.1.5' });

--- a/addon/serverless.js
+++ b/addon/serverless.js
@@ -120,8 +120,15 @@ router.get('/proxy/stream/:infoHash/:fileIdx', async (req, res) => {
   if (!/^[a-f0-9]{40}$/i.test(infoHash)) {
     return res.status(400).json({ error: 'Invalid infoHash' });
   }
+  let proxyUrl = null;
+  if (req.query.p) {
+    try { proxyUrl = Buffer.from(req.query.p, 'base64url').toString('utf8'); } catch {}
+    if (proxyUrl && !/^socks[45]?:\/\//i.test(proxyUrl)) {
+      return res.status(400).json({ error: 'Invalid proxy URL scheme (must be socks5://)' });
+    }
+  }
   try {
-    await streamTorrent(infoHash, parseInt(fileIdx, 10) || 0, req, res);
+    await streamTorrent(infoHash, parseInt(fileIdx, 10) || 0, req, res, proxyUrl);
   } catch (err) {
     logger.error(`Proxy stream error: ${err.message}`);
     if (!res.headersSent) res.status(500).json({ error: 'Stream failed' });

--- a/addon/serverless.js
+++ b/addon/serverless.js
@@ -115,16 +115,26 @@ router.get('/proxy/tvsubs/:id.srt', subtitleProxyLimiter, handleTvSubtitlesProxy
 router.get('/proxy/community/:id.srt', subtitleProxyLimiter, handleCommunitySubtitlesProxy);
 router.get('/proxy/translated/:id.srt', subtitleProxyLimiter, handleTranslatedSubtitleProxy);
 
-router.get('/proxy/stream/:infoHash/:fileIdx', async (req, res) => {
+const proxyStreamLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many proxy stream requests, try again later' },
+});
+
+router.get('/proxy/stream/:infoHash/:fileIdx', proxyStreamLimiter, async (req, res) => {
   const { infoHash, fileIdx } = req.params;
   if (!/^[a-f0-9]{40}$/i.test(infoHash)) {
     return res.status(400).json({ error: 'Invalid infoHash' });
   }
   let proxyUrl = null;
   if (req.query.p) {
-    try { proxyUrl = Buffer.from(req.query.p, 'base64url').toString('utf8'); } catch {}
+    try { proxyUrl = Buffer.from(req.query.p, 'base64url').toString('utf8'); } catch {
+      return res.status(400).json({ error: 'Invalid proxy parameter encoding' });
+    }
     if (proxyUrl && !/^socks[45]?:\/\//i.test(proxyUrl)) {
-      return res.status(400).json({ error: 'Invalid proxy URL scheme (must be socks5://)' });
+      return res.status(400).json({ error: 'Invalid proxy URL scheme (must be socks4:// or socks5://)' });
     }
   }
   try {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,11 @@ services:
       - PREWARM_MOVIE_LIMIT=${PREWARM_MOVIE_LIMIT:-500}
       - PREWARM_SERIES_LIMIT=${PREWARM_SERIES_LIMIT:-200}
       - PREWARM_CACHE_TTL=${PREWARM_CACHE_TTL:-86400}
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "1.0"
     depends_on:
       redis:
         condition: service_healthy
@@ -57,6 +62,11 @@ services:
       - ALASS_PATH=${ALASS_PATH:-}
       - SUBTITLE_SYNC_MAX_OFFSET_SECONDS=${SUBTITLE_SYNC_MAX_OFFSET_SECONDS:-300}
       - ALASS_SPLIT_PENALTY=${ALASS_SPLIT_PENALTY:-10}
+    deploy:
+      resources:
+        limits:
+          memory: 768M
+          cpus: "1.5"
     depends_on:
       redis:
         condition: service_healthy
@@ -76,6 +86,11 @@ services:
     container_name: magnetio_redis
     restart: unless-stopped
     command: redis-server --save 60 1 --loglevel warning --maxmemory 512mb --maxmemory-policy allkeys-lru --requirepass ${REDIS_PASSWORD:-magnetio-redis-secret}
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: "0.5"
     volumes:
       - ${REDIS_DATA_PATH:-redis_data}:/data
     networks:

--- a/scraper/index.js
+++ b/scraper/index.js
@@ -101,9 +101,17 @@ app.use((_req, res) => res.status(404).json({ error: 'Not found' }));
 
 // ─── Start ────────────────────────────────────────────────────────────────────
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   logger.info(`Magnetio scraper running on port ${PORT}`);
   startCronJobs();
 });
+
+const shutdown = () => {
+  logger.info('Shutting down…');
+  server.close(() => process.exit(0));
+  setTimeout(() => process.exit(1), 10_000);
+};
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);
 
 export default app;

--- a/scraper/lib/httpClient.js
+++ b/scraper/lib/httpClient.js
@@ -10,12 +10,11 @@ const DEFAULT_HEADERS = {
   'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
 };
 
-// Per-provider rate limiters (max 2 req/s to be polite)
 const limiters = new Map();
 
 function getLimiter(key) {
   if (!limiters.has(key)) {
-    limiters.set(key, new Bottleneck({ minTime: 500, maxConcurrent: 2 }));
+    limiters.set(key, new Bottleneck({ minTime: 250, maxConcurrent: 4 }));
   }
   return limiters.get(key);
 }

--- a/scraper/package-lock.json
+++ b/scraper/package-lock.json
@@ -272,16 +272,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {

--- a/scraper/providers/index.js
+++ b/scraper/providers/index.js
@@ -52,12 +52,11 @@ const ALL_PROVIDERS = [
   torznab,
 ];
 
-// Max 6 providers running simultaneously (up from 4 for faster throughput)
-const limit = pLimit(6);
-const PROVIDER_TIMEOUT_MS = parseInt(process.env.SCRAPER_PROVIDER_TIMEOUT_MS ?? '25000', 10);
+const limit = pLimit(parseInt(process.env.SCRAPER_CONCURRENCY ?? '12', 10));
+const PROVIDER_TIMEOUT_MS = parseInt(process.env.SCRAPER_PROVIDER_TIMEOUT_MS ?? '15000', 10);
 const HARD_TIMEOUT_MS     = parseInt(process.env.SCRAPER_HARD_TIMEOUT_MS     ?? String(PROVIDER_TIMEOUT_MS + 2000), 10);
-const EARLY_RETURN_MS     = parseInt(process.env.SCRAPER_EARLY_RETURN_MS     ?? '6000', 10);
-const MIN_EARLY_RESULTS   = parseInt(process.env.SCRAPER_MIN_EARLY_RESULTS   ?? '10', 10);
+const EARLY_RETURN_MS     = parseInt(process.env.SCRAPER_EARLY_RETURN_MS     ?? '3000', 10);
+const MIN_EARLY_RESULTS   = parseInt(process.env.SCRAPER_MIN_EARLY_RESULTS   ?? '3', 10);
 
 /**
  * Scrape all (or a subset of) providers for a given content item.

--- a/scraper/providers/index.js
+++ b/scraper/providers/index.js
@@ -52,7 +52,7 @@ const ALL_PROVIDERS = [
   torznab,
 ];
 
-const limit = pLimit(parseInt(process.env.SCRAPER_CONCURRENCY ?? '12', 10));
+const limit = pLimit(Math.max(1, parseInt(process.env.SCRAPER_CONCURRENCY ?? '12', 10) || 12));
 const PROVIDER_TIMEOUT_MS = parseInt(process.env.SCRAPER_PROVIDER_TIMEOUT_MS ?? '15000', 10);
 const HARD_TIMEOUT_MS     = parseInt(process.env.SCRAPER_HARD_TIMEOUT_MS     ?? String(PROVIDER_TIMEOUT_MS + 2000), 10);
 const EARLY_RETURN_MS     = parseInt(process.env.SCRAPER_EARLY_RETURN_MS     ?? '3000', 10);


### PR DESCRIPTION
## Summary

- **P2P Privacy Proxy**: Server-side torrent streaming via `torrent-stream` so user IPs never touch torrent swarms. LRU engine pool (max 3 for Raspberry Pi), HTTP Range support for seeking, optional SOCKS5 proxy for outbound connections
- **Per-user VPN/SOCKS5**: Each user can configure their own SOCKS5 proxy URL in the addon settings — torrent traffic routes through their VPN, not the server's IP. Engines are keyed per-user proxy
- **P2P exposure warning**: Landing page warns when no debrid service is configured, explaining IP risks and VPN mitigation
- **Stale-while-revalidate cache**: Cached content returns instantly (<50ms), background refresh happens async — biggest single UX improvement
- **Speed tuning**: Doubled scraper concurrency (6→12), halved timeouts (25s→15s), faster early return (6s→3s), relaxed per-provider throttling
- **Tracker init race fix**: Server no longer accepts requests before trackers are loaded (fixes empty P2P streams on cold start)
- **fileIdx fix**: No longer defaults to 0 on single-file torrents — fixes Android P2P streams (Issue #111)
- **Dynamic subtitle translation**: No longer hardcoded to Greek — derives from user's subtitle language preferences
- **Docker resource limits**: scraper 512M/1CPU, addon 768M/1.5CPU, redis 256M/0.5CPU (Raspberry Pi safety)
- **Graceful shutdown**: Both addon and scraper handle SIGTERM/SIGINT cleanly, destroying torrent engines and closing connections
- **Vulnerability fixes**: `ws` 1.x→8.21.2, `ip` 1.x→2.0.1, scoped overrides for path-to-regexp, send, uuid, tmp
- **Dead code removal**: Removed unused `SERVICE` constants from all 8 debrid modules and `chunkArray` from realdebrid

## Test plan

- [x] All 30 addon tests pass (`npm test`)
- [x] `npm audit` — scraper: 0 vulnerabilities; addon: only unfixable `ip` advisory (affects all versions, used only for torrent peer discovery)
- [ ] Verify landing page P2P warning appears when no debrid keys are set
- [ ] Verify proxy URL field shows when Privacy Proxy is enabled
- [ ] Verify streams show "🛡️ VPN Proxy" label when user proxy URL is configured
- [ ] Docker compose build and health checks pass on Raspberry Pi
- [ ] Stream loading time improved on cached content

Generated with Claude Code