### PR TITLE
Fix Docker build: use npm install instead of npm ci

### DIFF
--- a/addon/Dockerfile
+++ b/addon/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
 
 # Install dependencies separately for better layer caching
 COPY package*.json ./
-RUN npm ci --omit=dev
+RUN npm install --omit=dev
 
 # Copy source
 COPY . .


### PR DESCRIPTION
## Summary
- Replace `npm ci` with `npm install` in the addon Dockerfile
- `npm ci` fails with npm overrides (torrent-stream ws/ip overrides) in npm 10 — same issue that was fixed in the CI workflow in PR #116

The deploy from #116 failed because the Dockerfile still used `npm ci`.

Generated with Claude Code