### PR TITLE
Fix P2P streams not showing on some clients (#111)

### DIFF
--- a/addon/lib/streamInfo.js
+++ b/addon/lib/streamInfo.js
@@ -73,7 +73,8 @@ function buildSources(record) {
     .slice(0, 20)
     .map(tracker => `tracker:${tracker}`);
 
-  return trackers.length ? trackers : undefined;
+  const sources = [`dht:${record.infoHash}`, ...trackers];
+  return sources;
 }
 
 function getBingeGroup(record, quality) {

--- a/addon/test/sdk-upgrade.test.js
+++ b/addon/test/sdk-upgrade.test.js
@@ -138,7 +138,7 @@ test('stream info exposes tracker sources and subtitle matching hints', () => {
   }, {});
 
   assert.equal(stream.infoHash, 'abcdef0123456789abcdef0123456789abcdef01');
-  assert.deepEqual(stream.sources, ['tracker:udp://tracker.example:1337/announce']);
+  assert.deepEqual(stream.sources, ['dht:abcdef0123456789abcdef0123456789abcdef01', 'tracker:udp://tracker.example:1337/announce']);
   assert.equal(stream.behaviorHints.filename, 'Example.Release.1080p.WEB-DL.x265');
   assert.equal(stream.behaviorHints.videoSize, 2 * 1024 * 1024 * 1024);
   assert.match(stream.description, /WEB-DL/);


### PR DESCRIPTION
## Summary
- Add explicit `dht:<infoHash>` source entry to P2P stream objects
- Some Stremio clients require this to enable DHT peer discovery — without it, streams are returned by the API but silently dropped by the client

## Root cause
The `buildSources()` function only returned `tracker:` prefixed URLs. Torrentio (which works on the same clients) includes both `dht:` and `tracker:` entries. Clients that don't implicitly enable DHT from `infoHash` alone need the explicit `dht:` source.

## Test plan
- [x] All 30 tests pass (updated assertion to expect `dht:` entry)
- [ ] Verify P2P streams appear on Android clients after deploy

Fixes #111

Generated with Claude Code