### PR TITLE
Harden Raspberry Pi storage recovery

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,6 +103,7 @@ jobs:
       - name: Deploy with available storage
         env:
           DEPLOY_PATH: /home/peterdsp/magnetio-recovery
+          DEPLOY_MODE: native
         run: |
           set -euo pipefail
           "$DEPLOY_PATH/scripts/deploy-production.sh"

--- a/README.md
+++ b/README.md
@@ -517,6 +517,8 @@ The included workflow (`.github/workflows/deploy.yml`) handles automated deploym
 
 The workflow runs on a self-hosted GitHub Actions runner. Push to `main` triggers automatic deployment.
 
+The production workflow keeps Magnetio's Node.js services on the Raspberry Pi's SD card so the public addon remains available if USB media is slow or temporarily missing. Docker and its data can still live on `/mnt/media`; a systemd timer retries Docker automatically when that drive appears after boot. Set `DEPLOY_MODE=auto` or `DEPLOY_MODE=docker` when running `scripts/deploy-production.sh` manually to opt back into Compose deployment.
+
 ### Exposing to the Internet
 
 > **Don't want to self-host?** There's a public hosted instance at [magnetio.peterdsp.dev](https://magnetio.peterdsp.dev) (configure and install at [magnetio.peterdsp.dev/configure](https://magnetio.peterdsp.dev/configure)). Your Debrid keys still stay between your browser and your Debrid provider, the manifest URL just points at the hosted addon. The rest of this section is only relevant if you're running your own instance on a VPS or home server.

--- a/deploy/systemd/docker-media-recovery.service
+++ b/deploy/systemd/docker-media-recovery.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Retry Docker after the Magnetio media drive appears
+ConditionPathExists=/dev/disk/by-uuid/8d3ec5f0-5cbb-4a1e-838d-c69d41c8a319
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemctl --no-block start docker.service

--- a/deploy/systemd/docker-media-recovery.timer
+++ b/deploy/systemd/docker-media-recovery.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Periodically recover Docker after delayed USB disk enumeration
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=2min
+Persistent=true
+Unit=docker-media-recovery.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 DEPLOY_PATH="${DEPLOY_PATH:-/home/peterdsp/magnetio-recovery}"
 MEDIA_MOUNT="${MEDIA_MOUNT:-/mnt/media}"
+DEPLOY_MODE="${DEPLOY_MODE:-auto}"
 
 if [ "$DEPLOY_PATH" != "/home/peterdsp/magnetio-recovery" ]; then
   echo "Refusing unexpected deployment path: $DEPLOY_PATH" >&2
@@ -11,6 +12,14 @@ fi
 
 cd "$DEPLOY_PATH"
 
+case "$DEPLOY_MODE" in
+  auto|native|docker) ;;
+  *)
+    echo "Invalid DEPLOY_MODE: $DEPLOY_MODE (expected auto, native, or docker)" >&2
+    exit 1
+    ;;
+esac
+
 if [ ! -f .env ]; then
   cp .env.example .env
   sed -i 's#https://your-domain.example#https://magnetio.peterdsp.dev#' .env
@@ -18,7 +27,9 @@ if [ ! -f .env ]; then
 fi
 
 docker_ready=false
-if command -v findmnt >/dev/null 2>&1 && command -v docker >/dev/null 2>&1; then
+if [ "$DEPLOY_MODE" != "native" ] \
+  && command -v findmnt >/dev/null 2>&1 \
+  && command -v docker >/dev/null 2>&1; then
   configured_source="$(findmnt --fstab -rn -T "$MEDIA_MOUNT" -o SOURCE 2>/dev/null || true)"
   source_present=false
   case "$configured_source" in
@@ -42,6 +53,11 @@ if command -v findmnt >/dev/null 2>&1 && command -v docker >/dev/null 2>&1; then
   fi
 fi
 
+if [ "$DEPLOY_MODE" = "docker" ] && [ "$docker_ready" != true ]; then
+  echo "Docker deployment was requested, but persistent media storage is unavailable." >&2
+  exit 1
+fi
+
 if [ "$docker_ready" = true ]; then
   echo "Persistent media storage is available; deploying with Docker Compose."
   sudo systemctl stop magnetio-addon.service magnetio-scraper.service 2>/dev/null || true
@@ -52,7 +68,7 @@ if [ "$docker_ready" = true ]; then
   sudo systemctl disable magnetio-addon.service magnetio-scraper.service 2>/dev/null || true
   docker compose ps
 else
-  echo "Persistent media storage is unavailable; deploying native fallback on the SD card."
+  echo "Deploying Magnetio natively on the SD card (mode: $DEPLOY_MODE)."
 
   npm --prefix scraper ci --omit=dev
   # The addon lock carries overrides for legacy torrent-stream transitive
@@ -61,7 +77,10 @@ else
 
   sudo install -m 0644 deploy/systemd/magnetio-scraper.service /etc/systemd/system/magnetio-scraper.service
   sudo install -m 0644 deploy/systemd/magnetio-addon.service /etc/systemd/system/magnetio-addon.service
+  sudo install -m 0644 deploy/systemd/docker-media-recovery.service /etc/systemd/system/docker-media-recovery.service
+  sudo install -m 0644 deploy/systemd/docker-media-recovery.timer /etc/systemd/system/docker-media-recovery.timer
   sudo systemctl daemon-reload
+  sudo systemctl enable --now docker-media-recovery.timer
   sudo systemctl enable --now magnetio-scraper.service
   sudo systemctl enable --now magnetio-addon.service
 fi


### PR DESCRIPTION
## Summary
- keep Magnetio native on SD storage during production deploys so a slow USB disk cannot cause another public 502
- retry Docker automatically after the 2 TB media drive appears
- keep explicit auto and Docker deployment modes for manual use
- document the production recovery behavior

## Pi verification
- 2 TB Toshiba drive mounted at `/mnt/media` with 1.6 TB free
- SMART overall health and short self-test passed
- zero reallocated, pending, uncorrectable, or CRC-error sectors
- ext4 reports clean
- Docker restored at `/mnt/media/docker-data`
- Magnetio remains healthy from SD-native services