### PR TITLE
remove description from stream object

### DIFF
--- a/addon/lib/streamInfo.js
+++ b/addon/lib/streamInfo.js
@@ -32,7 +32,6 @@ export function toStreamInfo(record, config) {
   const stream = {
     name,
     title: description,
-    description,
     behaviorHints: {
       bingeGroup:      getBingeGroup(record, quality),
       filename:        filename || undefined,
@@ -49,7 +48,6 @@ export function toStreamInfo(record, config) {
     const proxyLabel = config.proxyUrl ? '🛡️ VPN Proxy' : '🛡️ Privacy Proxy';
     const proxyDesc = description + '\n' + proxyLabel;
     stream.title = proxyDesc;
-    stream.description = proxyDesc;
   } else {
     stream.infoHash = record.infoHash;
     stream.fileIdx = fileIdx;

--- a/addon/lib/streamInfo.js
+++ b/addon/lib/streamInfo.js
@@ -31,6 +31,7 @@ export function toStreamInfo(record, config) {
 
   const stream = {
     name,
+    // description removed for compatibility with Stremio desktop for windows (App Version: 6.0.1-beta.09)
     title: description,
     behaviorHints: {
       bingeGroup:      getBingeGroup(record, quality),

--- a/addon/test/sdk-upgrade.test.js
+++ b/addon/test/sdk-upgrade.test.js
@@ -179,7 +179,7 @@ test('stream info uses the Stremio-compatible infoHash contract and subtitle mat
   assert.equal(stream.sources, undefined);
   assert.equal(stream.behaviorHints.filename, 'Example.Release.1080p.WEB-DL.x265');
   assert.equal(stream.behaviorHints.videoSize, 2 * 1024 * 1024 * 1024);
-  assert.match(stream.description, /WEB-DL/);
+  assert.match(stream.title, /WEB-DL/);
 });
 
 test('OpenSubtitles API requests explicitly accept JSON responses', () => {


### PR DESCRIPTION
for some reason I dont see available torrents on stremio desktop for windows(App Version: 6.0.1-beta.09) unless I remove this filed from stream object. 