### PR TITLE
Add SMART media drive monitoring to production deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,9 @@ web_modules/
 .env.*
 !.env.example
 
+# smartd -> GitHub secret (real token file must never be committed; example is tracked)
+deploy/monitoring/smartd-github.env
+
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 .parcel-cache

--- a/deploy/monitoring/smartd-github.env.example
+++ b/deploy/monitoring/smartd-github.env.example
@@ -1,0 +1,15 @@
+# smartd -> GitHub issue integration for the media drive monitor.
+# Copy to /etc/smartd-github.env on the host (root-only, chmod 600) and fill in a token.
+# The deploy script installs this example to /etc/smartd-github.env only if that file
+# does not already exist, so your real token is never overwritten by a deploy.
+#
+# Create a FINE-GRAINED PAT scoped to peterdsp/Magnetio with:
+#   Repository permissions -> Issues: Read and write
+# Then set GITHUB_TOKEN below. With an empty token the notifier just logs to
+# syslog + wall and makes no GitHub call.
+GITHUB_TOKEN=
+GH_REPO=peterdsp/Magnetio
+# Optional: comma-separated labels that ALREADY EXIST in the repo, e.g. hardware,smart-alert
+#GH_LABELS=
+# Optional: seconds between duplicate issues for the same fault (default 43200 = 12h)
+#GH_COOLDOWN_SECS=43200

--- a/deploy/monitoring/smartd-notify
+++ b/deploy/monitoring/smartd-notify
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# smartd notifier.
+#  - ALWAYS: log to syslog (daemon.crit) + wall broadcast (works with no network).
+#  - OPTIONAL: open a GitHub issue if /etc/smartd-github.env provides a token.
+# smartd runs this as root via `-M exec`. Manual test: `sudo smartd-notify --github-test`.
+set -u
+
+FAILTYPE="${SMARTD_FAILTYPE:-manual}"
+DEVICE="${SMARTD_DEVICE:-unknown}"
+MESSAGE="${SMARTD_MESSAGE:-(no message)}"
+HOST="$(hostname)"
+TS="$(date '+%Y-%m-%d %H:%M:%S %Z')"
+
+if [ "${1:-}" = "--github-test" ]; then
+  FAILTYPE="GHTEST"
+  MESSAGE="Manual GitHub wiring test from ${HOST} at ${TS}. Safe to close."
+fi
+
+line="smartd ALERT [${FAILTYPE}] on ${DEVICE}: ${MESSAGE}"
+logger -t smartd-notify -p daemon.crit -- "$line"
+echo "$line" | wall 2>/dev/null || true
+
+# ---------- optional GitHub issue ----------
+ENVF=/etc/smartd-github.env
+[ -r "$ENVF" ] || exit 0
+# shellcheck disable=SC1090
+. "$ENVF"
+TOKEN="${GITHUB_TOKEN:-}"
+REPO="${GH_REPO:-}"
+[ -n "$TOKEN" ] && [ -n "$REPO" ] || exit 0
+
+# de-dup: at most one issue per fail type per cooldown window (default 12h)
+COOLDOWN="${GH_COOLDOWN_SECS:-43200}"
+STATE_DIR=/var/lib/smartd-notify
+mkdir -p "$STATE_DIR"
+key="$(printf '%s' "$FAILTYPE" | tr -c 'A-Za-z0-9' '_')"
+stamp="$STATE_DIR/last_${key}"
+now="$(date +%s)"
+if [ "$FAILTYPE" != "GHTEST" ] && [ -f "$stamp" ]; then
+  last="$(cat "$stamp" 2>/dev/null || echo 0)"
+  if [ $(( now - last )) -lt "$COOLDOWN" ]; then
+    logger -t smartd-notify "GitHub issue suppressed (cooldown ${COOLDOWN}s) for ${FAILTYPE}"
+    exit 0
+  fi
+fi
+
+HEALTH="$(smartctl -H -A -d sat "$DEVICE" 2>/dev/null | sed -n '1,45p' || true)"
+TITLE="[smartd] ${FAILTYPE} on ${HOST}:${DEVICE##*/}"
+
+# Build JSON safely with jq; include labels only if GH_LABELS is set (avoids 422).
+if [ -n "${GH_LABELS:-}" ]; then
+  LABELS_JSON="$(printf '%s' "$GH_LABELS" | jq -R 'split(",") | map(gsub("^ +| +$";""))')"
+else
+  LABELS_JSON='[]'
+fi
+PAYLOAD="$(jq -n \
+  --arg title "$TITLE" \
+  --arg host "$HOST" --arg dev "$DEVICE" --arg ft "$FAILTYPE" \
+  --arg ts "$TS" --arg msg "$MESSAGE" --arg health "$HEALTH" \
+  --argjson labels "$LABELS_JSON" \
+  '{title:$title,
+    labels:$labels,
+    body:("**Host:** \($host)\n**Device:** \($dev)\n**Fail type:** \($ft)\n**Time:** \($ts)\n\n**smartd message:**\n```\n\($msg)\n```\n\n**smartctl -H -A:**\n```\n\($health)\n```\n\n_Filed automatically by smartd-notify._")}
+  | if (.labels|length)==0 then del(.labels) else . end')"
+
+RESP="$(mktemp)"
+CODE="$(curl -s -m 20 -o "$RESP" -w '%{http_code}' \
+  -X POST \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "https://api.github.com/repos/${REPO}/issues" \
+  -d "$PAYLOAD" 2>/dev/null || echo 000)"
+if [ "$CODE" = "201" ]; then
+  URL="$(jq -r '.html_url // empty' "$RESP" 2>/dev/null)"
+  logger -t smartd-notify "GitHub issue created: ${URL}"
+  echo "$now" > "$stamp"
+else
+  ERR="$(jq -r '.message // empty' "$RESP" 2>/dev/null)"
+  logger -t smartd-notify -p daemon.err "GitHub issue FAILED (HTTP ${CODE}) ${ERR}"
+fi
+rm -f "$RESP"
+exit 0

--- a/deploy/monitoring/smartd.conf
+++ b/deploy/monitoring/smartd.conf
@@ -1,0 +1,10 @@
+# Magnetio media drive monitoring. Managed by ops session 2026-09-03.
+# Toshiba MQ04UBD200 (serial Y1FET1UYT) on externally-powered USB3 hub.
+# Referenced by stable ata- id so it survives sda/sdb re-enumeration.
+#  -d sat        : USB bridge needs SAT pass-through for SMART
+#  -a            : monitor health, prefail attrs, error+selftest logs (incl -C 197 -U 198)
+#  -o on / -S on : enable automatic offline testing + attribute autosave
+#  -s ...        : short self-test daily 02:xx, long self-test Saturday 03:xx (low-traffic)
+#  -W 4,55,60    : log temp change >=4C, warn 55C, critical 60C (drive idles ~32C)
+#  -M exec       : run our MTA-free notifier instead of emailing
+/dev/disk/by-id/ata-TOSHIBA_MQ04UBD200_Y1FET1UYT -d sat -a -o on -S on -s (S/../.././02|L/../../6/03) -W 4,55,60 -m root -M exec /usr/local/sbin/smartd-notify

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -26,6 +26,22 @@ if [ ! -f .env ]; then
   echo "Created .env from .env.example."
 fi
 
+# Host-level SMART monitoring for the 2 TB media drive. Independent of the deploy
+# mode, so install it regardless. Requires smartmontools (skipped if smartctl is
+# absent). The real GitHub token file is never overwritten once it exists.
+if command -v smartctl >/dev/null 2>&1; then
+  sudo install -m 0644 deploy/monitoring/smartd.conf /etc/smartd.conf
+  sudo install -m 0755 deploy/monitoring/smartd-notify /usr/local/sbin/smartd-notify
+  if [ ! -f /etc/smartd-github.env ]; then
+    sudo install -m 0600 deploy/monitoring/smartd-github.env.example /etc/smartd-github.env
+  fi
+  sudo systemctl enable smartmontools.service >/dev/null 2>&1 || true
+  sudo systemctl restart smartmontools.service || true
+  echo "Installed SMART drive monitoring (smartd)."
+else
+  echo "smartctl not found; skipping SMART drive monitoring install." >&2
+fi
+
 docker_ready=false
 if [ "$DEPLOY_MODE" != "native" ] \
   && command -v findmnt >/dev/null 2>&1 \


### PR DESCRIPTION
## Why
This session recovered the 2 TB media drive after a USB power fault and set up `smartd` monitoring live on the Pi. Those config artifacts only existed on the host and would be lost on a re-provision. This captures them in the repo so the deploy installs them.

## How
- `deploy/monitoring/smartd.conf` - monitors the drive by stable `ata-` id (`-d sat -a`), short self-test daily 02:xx, long weekly Sat 03:xx, temp warn 55C / crit 60C.
- `deploy/monitoring/smartd-notify` - MTA-free notifier: always logs to syslog + `wall`; optionally opens a de-duplicated GitHub issue when `/etc/smartd-github.env` provides a token.
- `deploy/monitoring/smartd-github.env.example` - tracked template; the real token file (`/etc/smartd-github.env`) is gitignored and never overwritten by a deploy.
- `scripts/deploy-production.sh` - installs the above and enables/restarts `smartmontools` in every deploy mode (skipped if `smartctl` is absent).

## Notes
- No secrets are committed. GitHub alerting stays dormant (syslog + wall only) until a token is added on the host.
- Drive verified healthy this session: SMART PASSED, zero reallocated/pending/uncorrectable/CRC sectors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)