### PR TITLE
On-demand debrid streams for services without a bulk cache-check

### DIFF
--- a/addon/lib/configuration.js
+++ b/addon/lib/configuration.js
@@ -113,6 +113,9 @@ export function parseConfiguration(configString) {
       case 'p2pfallback':
         config.p2pFallback = parseBoolean(value, config.p2pFallback);
         break;
+      case 'ondemand':
+        config.onDemand = parseBoolean(value, config.onDemand);
+        break;
       case 'excludesizes':
         config.excludeSizes = value.toUpperCase().split(',').filter(Boolean);
         break;
@@ -200,6 +203,7 @@ export function getDefaultConfiguration() {
     prewarmDebrid:      true,         // warm a few top uncached results in debrid
     prewarmLimit:       3,
     p2pFallback:        false,        // debrid configs stay direct-only unless explicitly enabled
+    onDemand:           true,         // show on-demand entries for debrid services lacking a cache-check
     debridCatalogs:     true,         // expose debrid cloud catalogs when a key is set
     excludeSizes:       [],
     maxSize:            null,

--- a/addon/lib/landingTemplate.js
+++ b/addon/lib/landingTemplate.js
@@ -65,6 +65,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
     prewarmDebrid: initialConfig.prewarmDebrid ?? true,
     prewarmLimit: initialConfig.prewarmLimit ?? 3,
     p2pFallback: initialConfig.p2pFallback ?? false,
+    onDemand: initialConfig.onDemand ?? true,
     debridCatalogs: initialConfig.debridCatalogs ?? true,
     tmdbApiKey: initialConfig.tmdbApiKey ?? '',
     torznabUrl: initialConfig.torznabUrl ?? '',
@@ -1175,6 +1176,13 @@ export function landingTemplate(manifest, initialConfig = {}) {
           </select>
         </label>
         <label>
+          On-demand streams for services without a cache check
+          <select id="onDemand" title="DebridLink, Offcloud and Put.io have no instant cache check. When enabled, they show on-demand entries that download to your Debrid account when you press play; when disabled, they contribute only catalogs and prewarm">
+            <option value="1">Enabled</option>
+            <option value="0">Disabled</option>
+          </select>
+        </label>
+        <label>
           Add Debrid cloud catalogs
           <select id="debridCatalogs" title="When a Debrid API key is set, also expose your cloud catalog (Movies/Series) in Stremio">
             <option value="1">Enabled</option>
@@ -1294,6 +1302,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
       document.getElementById('prewarm').value = initialConfig.prewarmDebrid === false ? '0' : '1';
       document.getElementById('prewarmLimit').value = String(initialConfig.prewarmLimit || 3);
       document.getElementById('p2pFallback').value = initialConfig.p2pFallback ? '1' : '0';
+      document.getElementById('onDemand').value = initialConfig.onDemand === false ? '0' : '1';
       document.getElementById('debridCatalogs').value = initialConfig.debridCatalogs === false ? '0' : '1';
       document.getElementById('proxyStreams').value = initialConfig.proxyStreams ? '1' : '0';
       document.getElementById('proxyUrl').value = initialConfig.proxyUrl || '';
@@ -1324,6 +1333,7 @@ export function landingTemplate(manifest, initialConfig = {}) {
       parts.push('prewarm=' + document.getElementById('prewarm').value);
       parts.push('prewarmLimit=' + document.getElementById('prewarmLimit').value);
       if (document.getElementById('p2pFallback').value === '1') parts.push('p2pFallback=1');
+      if (document.getElementById('onDemand').value === '0') parts.push('onDemand=0');
       var debridCatalogsValue = document.getElementById('debridCatalogs').value;
       if (debridCatalogsValue === '0') parts.push('debridCatalogs=0');
       var proxyValue = document.getElementById('proxyStreams').value;

--- a/addon/moch/moch.js
+++ b/addon/moch/moch.js
@@ -1,5 +1,5 @@
 import { MochOptions, MIN_API_KEY_LENGTH } from './options.js';
-import { isValidToken, buildDebridStream, buildOnDemandStream } from './mochHelper.js';
+import { isValidToken, buildDebridStream, buildOnDemandStream, raceTimeout } from './mochHelper.js';
 import { createStreamSubtitleProxies } from '../lib/subtitleProxy.js';
 import { cacheGet, cacheSet } from '../lib/cache.js';
 import NamedQueue from '../lib/namedQueue.js';
@@ -35,6 +35,14 @@ const resolveLimit = pLimit(4);
 // cache-check. Kept low so the stream list stays clean and the user is not
 // tempted to add many torrents to their debrid account at once.
 const ON_DEMAND_LIMIT = 5;
+
+// Hard ceiling for an on-demand /resolve call. Provider resolvers poll for the
+// torrent to become ready (roughly 20-36s worst case); this bounds the whole
+// request so the addon returns a clean error instead of hanging. On timeout the
+// in-flight resolve keeps running and warms resolveWithCache, so a retry can hit
+// the now-cached link. Override with ON_DEMAND_RESOLVE_TIMEOUT_MS.
+const ON_DEMAND_RESOLVE_TIMEOUT_MS =
+  parseInt(process.env.ON_DEMAND_RESOLVE_TIMEOUT_MS, 10) || 40_000;
 
 /**
  * Enhance a list of streams using all configured debrid services.
@@ -97,8 +105,9 @@ export async function applyMochs(streams, config, requestContext) {
 
         // Services without a bulk cache-check produce an empty cachedMap, so
         // the loop above yields nothing and they would vanish from the list.
-        // Emit visible on-demand entries instead, resolved on play.
-        if (moch.instantAvailability === false && typeof module.resolve === 'function') {
+        // Emit visible on-demand entries instead, resolved on play. Opt-out
+        // via `onDemand=0` in the config.
+        if (config?.onDemand !== false && moch.instantAvailability === false && typeof module.resolve === 'function') {
           const onDemand = buildOnDemandStreams(streams, cachedMap, moch, config);
           if (onDemand.length) {
             logger.info(
@@ -182,7 +191,13 @@ export async function resolveOnDemandStream(config, mochId, infoHash, fileIdx) {
     return null;
   }
 
-  return module.resolve({ infoHash, fileIdx }, apiKey);
+  // Bound the whole resolve so the /resolve route never hangs indefinitely.
+  // raceTimeout resolves to null on timeout (the underlying resolve continues
+  // in the background and warms the cache for a retry).
+  return raceTimeout(
+    () => module.resolve({ infoHash, fileIdx }, apiKey),
+    ON_DEMAND_RESOLVE_TIMEOUT_MS,
+  );
 }
 
 export function selectMochResults(directStreams, rawStreams, p2pFallback = false) {

--- a/addon/moch/moch.js
+++ b/addon/moch/moch.js
@@ -1,5 +1,5 @@
 import { MochOptions, MIN_API_KEY_LENGTH } from './options.js';
-import { isValidToken, buildDebridStream } from './mochHelper.js';
+import { isValidToken, buildDebridStream, buildOnDemandStream } from './mochHelper.js';
 import { createStreamSubtitleProxies } from '../lib/subtitleProxy.js';
 import { cacheGet, cacheSet } from '../lib/cache.js';
 import NamedQueue from '../lib/namedQueue.js';
@@ -31,6 +31,11 @@ const PREWARM_QUEUE = new NamedQueue(4);
 const RESOLVE_TIMEOUT_MS = 8_000;
 const resolveLimit = pLimit(4);
 
+// How many visible on-demand entries to emit per service that lacks a bulk
+// cache-check. Kept low so the stream list stays clean and the user is not
+// tempted to add many torrents to their debrid account at once.
+const ON_DEMAND_LIMIT = 5;
+
 /**
  * Enhance a list of streams using all configured debrid services.
  *
@@ -48,7 +53,8 @@ export async function applyMochs(streams, config, requestContext) {
   const enabled = getEnabledMochs(config);
   if (!enabled.length) return streams;
 
-  const directStreams = [];
+  const directStreams = [];    // instantly-cached, resolved to a direct link
+  const onDemandStreams = [];   // visible fallbacks for services without cache-check
 
   await Promise.allSettled(
     enabled.map(async ({ key, moch, module }) => {
@@ -88,14 +94,36 @@ export async function applyMochs(streams, config, requestContext) {
           }
           directStreams.push(debridStream);
         }
+
+        // Services without a bulk cache-check produce an empty cachedMap, so
+        // the loop above yields nothing and they would vanish from the list.
+        // Emit visible on-demand entries instead, resolved on play.
+        if (moch.instantAvailability === false && typeof module.resolve === 'function') {
+          const onDemand = buildOnDemandStreams(streams, cachedMap, moch, config);
+          if (onDemand.length) {
+            logger.info(
+              `Moch on-demand [${moch.name}]: no bulk cache-check, ` +
+              `emitting ${onDemand.length} on-demand stream(s)`
+            );
+            onDemandStreams.push(...onDemand);
+          } else {
+            logger.warn(
+              `Moch on-demand [${moch.name}]: no bulk cache-check and no resolvable ` +
+              `candidates (missing public base URL or config context)`
+            );
+          }
+        }
       } catch (err) {
         logger.error(`Moch error [${moch.name}]: ${err.message}`);
       }
     })
   );
 
-  const results = selectMochResults(directStreams, streams, config?.p2pFallback);
-  if (directStreams.length) return results;
+  // Instant (cached) streams first, on-demand fallbacks after, so on-demand
+  // entries only surface when few or no cached streams filled the list.
+  const resolved = [...directStreams, ...onDemandStreams];
+  const results = selectMochResults(resolved, streams, config?.p2pFallback);
+  if (resolved.length) return results;
 
   if (config?.p2pFallback) {
     logger.warn(`No debrid streams resolved, falling back to P2P (${streams.length} raw streams)`);
@@ -103,6 +131,58 @@ export async function applyMochs(streams, config, requestContext) {
     logger.warn('No debrid streams resolved and P2P fallback is disabled');
   }
   return results;
+}
+
+/**
+ * Build visible on-demand entries for a service without a bulk cache-check.
+ * Each entry's URL points back at the addon's own /resolve route, which does
+ * the add + unrestrict on play and 302-redirects to the real link.
+ */
+function buildOnDemandStreams(streams, cachedMap, moch, config) {
+  const base = config?._publicBaseUrl;
+  const configString = config?._configString;
+  // Without an absolute base and the raw config segment we cannot build a
+  // resolve URL the app can call back into. Skip rather than emit dead links.
+  if (!base || !configString) return [];
+
+  const picked = [];
+  const seen = new Set();
+
+  for (const stream of streams) {
+    const infoHash = stream.infoHash?.toLowerCase();
+    if (!infoHash) continue;
+    if (cachedMap.has(infoHash)) continue; // already emitted as a direct stream
+
+    const fileIdx = stream.fileIdx ?? 0;
+    const key = `${infoHash}:${fileIdx}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const resolveUrl = `${base}/${configString}/resolve/${moch.id}/${infoHash}/${fileIdx}`;
+    picked.push(buildOnDemandStream(stream, resolveUrl, moch.name));
+
+    if (picked.length >= ON_DEMAND_LIMIT) break;
+  }
+
+  return picked;
+}
+
+/**
+ * Resolve a single torrent on demand for a given service (used by the addon's
+ * /resolve route). Returns a direct URL or null.
+ */
+export async function resolveOnDemandStream(config, mochId, infoHash, fileIdx) {
+  const entry = findMochByShortId(mochId);
+  if (!entry) return null;
+
+  const { moch, module } = entry;
+  const apiKey = config?.[moch.configKey];
+
+  if (!isValidToken(apiKey, MIN_API_KEY_LENGTH) || typeof module.resolve !== 'function') {
+    return null;
+  }
+
+  return module.resolve({ infoHash, fileIdx }, apiKey);
 }
 
 export function selectMochResults(directStreams, rawStreams, p2pFallback = false) {

--- a/addon/moch/mochHelper.js
+++ b/addon/moch/mochHelper.js
@@ -82,6 +82,30 @@ export function buildDebridStream(baseStream, url, serviceName) {
   };
 }
 
+/**
+ * Build a visible "on-demand" stream for services without a bulk cache-check.
+ *
+ * The URL points back at the addon's own /resolve route, which performs the
+ * add + unrestrict when the user presses play and then 302-redirects to the
+ * real debrid link. This keeps such services visibly present in the stream
+ * list instead of silently contributing nothing.
+ */
+export function buildOnDemandStream(baseStream, resolveUrl, serviceName) {
+  const title = `${baseStream.title ?? ''}\n⏳ On-demand via ${serviceName} - press play to cache (no instant check)`.trim();
+
+  return {
+    url:   resolveUrl,
+    name:  `${baseStream.name ?? '⚡ Magnetio'}\n[${serviceName} ⏳]`,
+    title,
+    behaviorHints: {
+      ...(baseStream.behaviorHints ?? {}),
+      // The final target type is unknown until resolution, so force
+      // server-side handling rather than assuming a web-ready file.
+      notWebReady: true,
+    },
+  };
+}
+
 function isWebReadyUrl(url) {
   if (!/^https:\/\//i.test(url)) return false;
   return /\.(mp4|m4v)(?:$|[?#])/i.test(url);

--- a/addon/moch/options.js
+++ b/addon/moch/options.js
@@ -7,6 +7,12 @@
  *   shortName  – abbreviated name shown in the addon title
  *   name       – full display name
  *   hasCatalog – whether the service exposes a browsable catalog
+ *   instantAvailability – whether the service offers a bulk cache-check.
+ *                         When false, the moch layer cannot know ahead of
+ *                         time which torrents are cached, so instead of
+ *                         silently contributing nothing it emits visible
+ *                         on-demand entries that resolve when the user
+ *                         presses play.
  */
 export const MochOptions = {
   realdebrid: {
@@ -15,6 +21,7 @@ export const MochOptions = {
     shortName:  'RD',
     name:       'Real-Debrid',
     hasCatalog: true,
+    instantAvailability: true,
   },
   premiumize: {
     id:         'pm',
@@ -22,6 +29,7 @@ export const MochOptions = {
     shortName:  'PM',
     name:       'Premiumize',
     hasCatalog: true,
+    instantAvailability: true,
   },
   alldebrid: {
     id:         'ad',
@@ -29,6 +37,7 @@ export const MochOptions = {
     shortName:  'AD',
     name:       'AllDebrid',
     hasCatalog: false,
+    instantAvailability: true,
   },
   debridlink: {
     id:         'dl',
@@ -36,6 +45,7 @@ export const MochOptions = {
     shortName:  'DL',
     name:       'DebridLink',
     hasCatalog: true,
+    instantAvailability: false,
   },
   easydebrid: {
     id:         'ed',
@@ -43,6 +53,7 @@ export const MochOptions = {
     shortName:  'ED',
     name:       'EasyDebrid',
     hasCatalog: false,
+    instantAvailability: true,
   },
   offcloud: {
     id:         'oc',
@@ -50,6 +61,7 @@ export const MochOptions = {
     shortName:  'OC',
     name:       'Offcloud',
     hasCatalog: false,
+    instantAvailability: false,
   },
   torbox: {
     id:         'tb',
@@ -57,6 +69,7 @@ export const MochOptions = {
     shortName:  'TB',
     name:       'TorBox',
     hasCatalog: true,
+    instantAvailability: true,
   },
   putio: {
     id:         'pu',
@@ -64,6 +77,7 @@ export const MochOptions = {
     shortName:  'PU',
     name:       'Put.io',
     hasCatalog: true,
+    instantAvailability: false,
   },
 };
 

--- a/addon/serverless.js
+++ b/addon/serverless.js
@@ -5,6 +5,7 @@ import StremioAddonSdk from 'stremio-addon-sdk';
 import { dummyManifest } from './lib/manifest.js';
 import { getDefaultConfiguration, parseConfiguration } from './lib/configuration.js';
 import { getAddonInterface } from './addon.js';
+import { resolveOnDemandStream } from './moch/moch.js';
 import { landingTemplate } from './lib/landingTemplate.js';
 import { statsDashboard } from './lib/statsDashboard.js';
 import { logger } from './lib/logger.js';
@@ -192,6 +193,48 @@ router.get('/:configuration/configure', (req, res) => {
   }
 });
 
+// On-demand debrid resolution for services without a bulk cache-check.
+// The stream URL emitted by the moch layer points here; we add + unrestrict
+// the torrent now and 302-redirect to the real direct link.
+const onDemandResolveLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many resolve requests, try again later' },
+});
+
+router.get('/:configuration/resolve/:moch/:infoHash/:fileIdx', onDemandResolveLimiter, async (req, res) => {
+  const { configuration, moch, infoHash, fileIdx } = req.params;
+
+  if (!/^[a-f0-9]{40}$/i.test(infoHash)) {
+    return res.status(400).json({ error: 'Invalid infoHash' });
+  }
+
+  const clientIp = req.ip || req.connection?.remoteAddress;
+
+  runWithClientIp(clientIp, async () => {
+    try {
+      const config = parseConfiguration(configuration);
+      const url = await resolveOnDemandStream(
+        config,
+        moch,
+        infoHash.toLowerCase(),
+        parseInt(fileIdx, 10) || 0,
+      );
+
+      if (!url) {
+        return res.status(502).json({ error: 'Debrid could not cache this torrent in time' });
+      }
+
+      res.redirect(302, url);
+    } catch (err) {
+      logger.error(`On-demand resolve error: ${err.message}`);
+      if (!res.headersSent) res.status(500).json({ error: 'Resolve failed' });
+    }
+  });
+});
+
 router.use('/:configuration', globalLimiter, async (req, res, next) => {
   const clientIp = req.ip || req.connection?.remoteAddress;
 
@@ -230,6 +273,7 @@ async function getConfiguredAddonRouter(configString, publicBaseUrl) {
 
   const config = parseConfiguration(configString);
   config._publicBaseUrl = publicBaseUrl;
+  config._configString = configString;
   const addonInterface = await getAddonInterface(config);
   const addonRouter = getSdkRouter(addonInterface);
 

--- a/addon/test/sdk-upgrade.test.js
+++ b/addon/test/sdk-upgrade.test.js
@@ -10,7 +10,7 @@ import { toSubtitleLanguageCode } from '../lib/languages.js';
 import { toStreamInfo } from '../lib/streamInfo.js';
 import { computeOpenSubtitlesHashFromBuffers, createStreamSubtitleProxies } from '../lib/subtitleProxy.js';
 import { pickPrewarmCandidates, selectMochResults } from '../moch/moch.js';
-import { buildOnDemandStream } from '../moch/mochHelper.js';
+import { buildOnDemandStream, raceTimeout } from '../moch/mochHelper.js';
 import { MochOptions } from '../moch/options.js';
 import { buildCacheCheckBody, buildTorrentForm, parseCachedHashes } from '../moch/torbox.js';
 import { applyFinalStreamLimit } from '../addon.js';
@@ -41,6 +41,12 @@ test('P2P fallback is strict by default and can be explicitly enabled', () => {
   assert.equal(parseConfiguration('p2pFallback=1').p2pFallback, true);
 });
 
+test('on-demand streams are on by default and can be disabled', () => {
+  assert.equal(parseConfiguration('').onDemand, true);
+  assert.equal(parseConfiguration('onDemand=0').onDemand, false);
+  assert.equal(parseConfiguration('onDemand=1').onDemand, true);
+});
+
 test('debrid selection preserves direct-only mode and optional P2P fallback', () => {
   const direct = [{ url: 'https://debrid.example/video' }];
   const raw = [{ infoHash: 'abcdef' }];
@@ -61,6 +67,14 @@ test('services without a bulk cache-check are flagged for on-demand resolution',
   for (const key of withCacheCheck) {
     assert.equal(MochOptions[key].instantAvailability, true, `${key} should be instant`);
   }
+});
+
+test('on-demand resolve ceiling returns null on timeout and value when fast', async () => {
+  const slow = () => new Promise(resolve => setTimeout(() => resolve('late'), 50));
+  const fast = () => Promise.resolve('https://debrid.example/video');
+
+  assert.equal(await raceTimeout(slow, 10), null);
+  assert.equal(await raceTimeout(fast, 1000), 'https://debrid.example/video');
 });
 
 test('on-demand stream is a visible, labelled redirect back into the addon', () => {

--- a/addon/test/sdk-upgrade.test.js
+++ b/addon/test/sdk-upgrade.test.js
@@ -10,6 +10,8 @@ import { toSubtitleLanguageCode } from '../lib/languages.js';
 import { toStreamInfo } from '../lib/streamInfo.js';
 import { computeOpenSubtitlesHashFromBuffers, createStreamSubtitleProxies } from '../lib/subtitleProxy.js';
 import { pickPrewarmCandidates, selectMochResults } from '../moch/moch.js';
+import { buildOnDemandStream } from '../moch/mochHelper.js';
+import { MochOptions } from '../moch/options.js';
 import { buildCacheCheckBody, buildTorrentForm, parseCachedHashes } from '../moch/torbox.js';
 import { applyFinalStreamLimit } from '../addon.js';
 
@@ -47,6 +49,38 @@ test('debrid selection preserves direct-only mode and optional P2P fallback', ()
   assert.deepEqual(selectMochResults([], raw), []);
   assert.deepEqual(selectMochResults(direct, raw, true), [...direct, ...raw]);
   assert.deepEqual(selectMochResults([], raw, true), raw);
+});
+
+test('services without a bulk cache-check are flagged for on-demand resolution', () => {
+  const noCacheCheck = ['debridlink', 'offcloud', 'putio'];
+  const withCacheCheck = ['realdebrid', 'premiumize', 'alldebrid', 'torbox', 'easydebrid'];
+
+  for (const key of noCacheCheck) {
+    assert.equal(MochOptions[key].instantAvailability, false, `${key} should be on-demand`);
+  }
+  for (const key of withCacheCheck) {
+    assert.equal(MochOptions[key].instantAvailability, true, `${key} should be instant`);
+  }
+});
+
+test('on-demand stream is a visible, labelled redirect back into the addon', () => {
+  const base = {
+    name: '⚡ Magnetio\n1080P',
+    title: 'The Matrix (1999)\n👥 842 💾 2.1 GB',
+    behaviorHints: { bingeGroup: 'magnetio|1080p' },
+  };
+  const resolveUrl = 'https://host/CONFIG/resolve/pu/88594aaacbde40ef3e2510c47374ec0aa396c08e/0';
+
+  const stream = buildOnDemandStream(base, resolveUrl, 'Put.io');
+
+  assert.equal(stream.url, resolveUrl);
+  assert.match(stream.name, /\[Put\.io ⏳\]/);
+  assert.match(stream.title, /On-demand via Put\.io/);
+  assert.equal(stream.behaviorHints.notWebReady, true);
+  // preserves inherited hints
+  assert.equal(stream.behaviorHints.bingeGroup, 'magnetio|1080p');
+  // it is a direct-url stream, never a raw torrent
+  assert.equal(stream.infoHash, undefined);
 });
 
 test('TorBox cache checks use the documented batch request and response shape', () => {


### PR DESCRIPTION
## Why

DebridLink, Offcloud, and Put.io do not expose a bulk instant-availability (cache-check) endpoint. Because `applyMochs` only resolves infoHashes present in the cached map, these three services silently contributed **nothing** to the stream list during normal playback, reading as "broken" to users who had only one of them configured. They previously surfaced only via the debrid catalog and background prewarm.

## How

- **Flag the capability** — `moch/options.js` gains `instantAvailability` per service (`false` for DebridLink/Offcloud/Put.io, `true` for the other five).
- **Emit visible on-demand entries** — for services with `instantAvailability: false`, the moch layer emits up to 5 labelled `[Service ⏳]` entries whose `url` points at a new addon route. Instant (cached) streams still sort first, so on-demand rows only surface when the list would otherwise be thin.
- **Resolve on play** — new route `GET /:configuration/resolve/:moch/:infoHash/:fileIdx` (rate-limited, registered before the SDK catch-all) does the add + unrestrict and 302-redirects to the real link.
- **Config gate** — new `onDemand` flag (default **on**) with a dropdown on the configure page; opt out with `onDemand=0`.
- **Timeout ceiling** — the resolve is bounded by `ON_DEMAND_RESOLVE_TIMEOUT_MS` (default 40s, env-overridable) so the request never hangs; on timeout the in-flight resolve keeps warming `resolveWithCache` so a retry can hit the cached link.

## Trade-off

Pressing an on-demand entry adds a torrent to the user's debrid account and can take some seconds to cache (bounded by the ceiling). Nothing happens until the user presses play, and the list is capped at 5 per service.

## Tests

`node --test` in `addon/` — 39/39 pass, including new tests for the capability flags, the on-demand stream shape, the `onDemand` flag parsing, and the timeout ceiling.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)