### PR TITLE
Bump qs to 6.16.0 in /addon (clears 2 dependabot advisories)

### DIFF
--- a/addon/package-lock.json
+++ b/addon/package-lock.json
@@ -2517,9 +2517,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/addon/package.json
+++ b/addon/package.json
@@ -35,6 +35,7 @@
     "nodemon": "^3.0.2"
   },
   "overrides": {
+    "qs": "6.16.0",
     "swagger-stats": {
       "prom-client": "$prom-client",
       "send": "0.19.0",


### PR DESCRIPTION
## Why

The `/addon` lockfile resolved `qs` to `6.15.3` (transitive via express 4 through `stremio-addon-sdk`, and express 5 directly). Two open **MEDIUM** dependabot alerts cover this range; both are fixed in `qs@6.16.0`. The `/scraper` copy was already bumped in #127; this does the same for `/addon`.

## How

Add a top-level `qs: 6.16.0` override in `addon/package.json` so every transitive copy resolves to `6.16.0`, and regenerate `package-lock.json`. Patch-level bump, semver-compatible with `body-parser` on both express 4 and 5.

## Verification

- `npm ls qs` → all copies now `6.16.0`.
- `node --test` in `addon/` → 35/35 pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)