### PR TITLE
Document why the ip@2.0.1 override is safe (unexploitable advisory)

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "nodemon": "^3.0.2"
   },
+  "//ip-advisory": "ip is force-pinned to 2.0.1 below via the torrent-stream override. GHSA-2p57-rm9w-gvfp (ip <=2.0.1, no upstream fix) is not exploitable here: the vulnerable isPublic/isPrivate/isLoopback classifiers are never called in our dependency tree (torrent-stream's peer-blocklist feature is unused), so the resolver only ever uses ip.toLong/cidrSubnet. Do not remove the pin without re-checking reachability.",
   "overrides": {
     "qs": "6.16.0",
     "swagger-stats": {


### PR DESCRIPTION
## Why

The `torrent-stream` override pins `ip` to `2.0.1`, which dependabot flags via **GHSA-2p57-rm9w-gvfp** (`ip <= 2.0.1`, no upstream fix). Investigation showed the advisory is **not exploitable** in this codebase, but that finding was undocumented and at risk of being re-litigated.

## What was verified

- The vulnerable classifiers `ip.isPublic()` / `isPrivate()` / `isLoopback()` are **never called** anywhere in the addon's dependency tree.
- `ip` reaches us only via `torrent-stream` → `ip-set` (uses `ip.toLong`/`cidrSubnet`, arithmetic only) and `torrent-stream` → `bittorrent-tracker` (the classifying code is server-side; we use the client path).
- `ip-set` is exercised only by `torrent-stream`'s peer-**blocklist** feature, which `addon/lib/torrentProxy.js` never enables, so it short-circuits on an empty set.
- The proxy route is opt-in (`proxyStreams` defaults false), rate-limited, and infoHash-validated; it connects outbound to BT peers, so there is no SSRF sink for this bug to bypass.

## How

Add a one-line rationale next to the override using an npm-tolerated `//` comment key (package.json cannot carry inline comments). No dependency or lockfile change.

This documents the override; it does **not** dismiss the dependabot alert (left to a maintainer). Longer term, migrating off the unmaintained `torrent-stream` removes `ip` at the source.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)