### PR TITLE
Harden Torznab SSRF guard against numeric and IPv6 host encodings

### DIFF
--- a/scraper/providers/torznab.js
+++ b/scraper/providers/torznab.js
@@ -2,6 +2,8 @@
  * Torznab provider -- queries any Torznab-compatible endpoint (Jackett, Prowlarr, etc.).
  * Conditionally active: returns [] when no torznabUrl is configured.
  */
+import net from 'node:net';
+import { lookup } from 'node:dns/promises';
 import * as cheerio from 'cheerio';
 import { get } from '../lib/httpClient.js';
 import { parseTitle, buildSearchQuery } from '../lib/titleHelper.js';
@@ -18,7 +20,7 @@ export async function scrape(meta) {
   const apiKey  = meta.torznabApiKey;
   if (!baseUrl) return [];
 
-  if (!isUrlSafe(baseUrl)) {
+  if (!(await isUrlSafe(baseUrl))) {
     logger.warn('[Torznab] Rejected unsafe or invalid URL');
     return [];
   }
@@ -127,22 +129,138 @@ function attrValue(item, attrName) {
   return el.length ? el.attr('value') : null;
 }
 
-function isUrlSafe(urlStr) {
+const INTERNAL_SUFFIXES = ['.localhost', '.local', '.internal'];
+const DNS_TIMEOUT_MS = 5_000;
+
+/**
+ * SSRF guard for the user-supplied Torznab base URL.
+ *
+ * A plain string match on the hostname is not enough: an internal address can
+ * be written as a decimal, hex or octal integer (http://2130706433/ is
+ * 127.0.0.1), as an IPv6 literal (http://[::1]/) or as an IPv4-mapped IPv6
+ * address (http://[::ffff:127.0.0.1]/), none of which look like "127.0.0.1" or
+ * "10.x". So we range-check the actual address bytes instead, and for real
+ * hostnames we resolve them and range-check every answer.
+ *
+ * Async because of the DNS lookup. This narrows the attack surface but does not
+ * defeat active DNS rebinding, which would need the resolved IP to be pinned at
+ * connect time (a change to the HTTP layer, out of scope here).
+ */
+export async function isUrlSafe(urlStr) {
+  let parsed;
   try {
-    const parsed = new URL(urlStr);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
-    const host = parsed.hostname;
-    if (host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '0.0.0.0') return false;
-    if (host.startsWith('10.')) return false;
-    if (host.startsWith('192.168.')) return false;
-    if (host.startsWith('169.254.')) return false;
-    if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return false;
-    if (host.endsWith('.local') || host.endsWith('.internal')) return false;
-    if (host.includes('metadata.google') || host.includes('metadata.aws')) return false;
-    return true;
+    parsed = new URL(urlStr);
   } catch {
     return false;
   }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+
+  // new URL() canonicalises numeric IPv4 forms to dotted-decimal and returns
+  // IPv6 literals wrapped in brackets. Drop the brackets so net.isIP() and the
+  // range checks see a bare address.
+  let host = parsed.hostname.toLowerCase();
+  if (host.startsWith('[') && host.endsWith(']')) host = host.slice(1, -1);
+
+  // Literal IP (v4 or v6, in any encoding): check the bytes directly, no DNS.
+  if (net.isIP(host) !== 0) return !isPrivateIp(host);
+
+  // Hostname: reject names that never point at a public host, then resolve the
+  // rest and reject if any resolved address is private or reserved.
+  if (host === 'localhost' || INTERNAL_SUFFIXES.some(s => host.endsWith(s))) return false;
+  return !(await resolvesToPrivate(host));
+}
+
+async function resolvesToPrivate(host) {
+  try {
+    const addrs = await withTimeout(lookup(host, { all: true }), DNS_TIMEOUT_MS);
+    if (!addrs.length) return true;                     // no address, cannot verify
+    return addrs.some(a => isPrivateIp(a.address));
+  } catch {
+    return true;                                        // lookup failed or timed out, fail closed
+  }
+}
+
+function withTimeout(promise, ms) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error('dns timeout')), ms);
+    timer.unref?.();
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+/**
+ * True when an IP literal (v4 or v6) is loopback, private, link-local,
+ * carrier-grade NAT, multicast or otherwise not a public unicast address.
+ * Anything that is not a valid literal is treated as unsafe (fail closed).
+ */
+export function isPrivateIp(ip) {
+  const family = net.isIP(ip);
+  if (family === 4) return isPrivateIpv4(ip);
+  if (family === 6) return isPrivateIpv6(ip);
+  return true;
+}
+
+function isPrivateIpv4(ip) {
+  const p = ip.split('.').map(Number);
+  if (p.length !== 4 || p.some(n => !Number.isInteger(n) || n < 0 || n > 255)) return true;
+  const [a, b, c] = p;
+  if (a === 0)   return true;                            // 0.0.0.0/8    this host
+  if (a === 10)  return true;                            // 10.0.0.0/8   private
+  if (a === 127) return true;                            // 127.0.0.0/8  loopback
+  if (a === 100 && b >= 64 && b <= 127) return true;     // 100.64.0.0/10 carrier-grade NAT
+  if (a === 169 && b === 254) return true;               // 169.254.0.0/16 link-local (incl. 169.254.169.254 metadata)
+  if (a === 172 && b >= 16 && b <= 31) return true;      // 172.16.0.0/12 private
+  if (a === 192 && b === 0 && c === 0) return true;      // 192.0.0.0/24  IETF protocol assignments
+  if (a === 192 && b === 168) return true;               // 192.168.0.0/16 private
+  if (a === 198 && (b === 18 || b === 19)) return true;  // 198.18.0.0/15 benchmarking
+  if (a >= 224) return true;                             // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved
+  return false;
+}
+
+function isPrivateIpv6(addr) {
+  const b = ipv6ToBytes(addr);
+  if (b.length !== 16) return true;
+  // IPv4-mapped ::ffff:0:0/96 and IPv4-compatible ::/96 (which also covers ::,
+  // ::1 and the deprecated ::a.b.c.d form): defer to the embedded IPv4 checks.
+  if (b.slice(0, 10).every(x => x === 0) && b[10] === 0xff && b[11] === 0xff)
+    return isPrivateIpv4(`${b[12]}.${b[13]}.${b[14]}.${b[15]}`);
+  if (b.slice(0, 12).every(x => x === 0))
+    return isPrivateIpv4(`${b[12]}.${b[13]}.${b[14]}.${b[15]}`);
+  if ((b[0] & 0xfe) === 0xfc) return true;                   // fc00::/7  unique local
+  if (b[0] === 0xfe && (b[1] & 0xc0) === 0x80) return true;  // fe80::/10 link-local
+  if (b[0] === 0xff) return true;                            // ff00::/8  multicast
+  if (b[0] === 0x20 && b[1] === 0x01 && b[2] === 0x0d && b[3] === 0xb8) return true; // 2001:db8::/32 docs
+  return false;
+}
+
+// Expand a net.isIP()-validated IPv6 literal into its 16 bytes, first rewriting
+// any embedded dotted-quad tail (e.g. ::ffff:127.0.0.1) into two hextets.
+function ipv6ToBytes(addr) {
+  addr = addr.toLowerCase();
+  if (addr.includes('.')) {
+    const idx = addr.lastIndexOf(':');
+    const o = addr.slice(idx + 1).split('.').map(n => parseInt(n, 10));
+    const hi = ((o[0] << 8) | o[1]).toString(16);
+    const lo = ((o[2] << 8) | o[3]).toString(16);
+    addr = `${addr.slice(0, idx + 1)}${hi}:${lo}`;
+  }
+  let groups;
+  if (addr.includes('::')) {
+    const [head, tail] = addr.split('::');
+    const headParts = head ? head.split(':') : [];
+    const tailParts = tail ? tail.split(':') : [];
+    const missing = 8 - (headParts.length + tailParts.length);
+    groups = [...headParts, ...Array(Math.max(0, missing)).fill('0'), ...tailParts];
+  } else {
+    groups = addr.split(':');
+  }
+  const bytes = [];
+  for (const g of groups) {
+    const v = parseInt(g || '0', 16);
+    bytes.push((v >> 8) & 0xff, v & 0xff);
+  }
+  return bytes;
 }
 
 function base32ToHex(base32) {

--- a/scraper/test/torznab-ssrf.test.js
+++ b/scraper/test/torznab-ssrf.test.js
@@ -1,0 +1,128 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isUrlSafe, isPrivateIp } from '../providers/torznab.js';
+
+// Each of these hostnames resolves to an internal address but is written in a
+// form the old string/prefix checks missed. isUrlSafe() must reject them all.
+// All are IP literals, so no DNS lookup happens and the tests stay offline.
+const UNSAFE_URLS = [
+  // Loopback 127.0.0.1 in every IPv4 encoding.
+  'http://127.0.0.1/',
+  'http://2130706433/',      // decimal
+  'http://0x7f000001/',      // hex
+  'http://0177.0.0.1/',      // octal first octet
+  'http://017700000001/',    // full octal
+  'http://0x7f.0.0.1/',      // mixed hex
+  'http://127.1/',           // short form
+  // Private and reserved IPv4 ranges, including numeric encodings.
+  'http://10.0.0.1/',
+  'http://192.168.1.1/',
+  'http://3232235521/',      // decimal 192.168.0.1
+  'http://0xC0A80001/',      // hex 192.168.0.1
+  'http://172.16.0.1/',
+  'http://172.31.255.255/',
+  'http://169.254.169.254/', // cloud metadata
+  'http://100.64.0.1/',      // carrier-grade NAT
+  'http://0.0.0.0/',
+  // IPv6 loopback / unspecified / internal ranges.
+  'http://[::1]/',
+  'http://[::]/',
+  'http://[fe80::1]/',       // link-local
+  'http://[fc00::1]/',       // unique local
+  'http://[fd12:3456:789a::1]/',
+  'http://[ff02::1]/',       // multicast
+  // IPv4-mapped and IPv4-compatible IPv6 pointing back at internal v4.
+  'http://[::ffff:127.0.0.1]/',
+  'http://[::ffff:7f00:1]/',
+  'http://[::ffff:10.0.0.1]/',
+  'http://[::ffff:169.254.169.254]/',
+  'http://[::ffff:a9fe:a9fe]/',
+  'http://[::127.0.0.1]/',
+];
+
+for (const url of UNSAFE_URLS) {
+  test(`isUrlSafe rejects internal address: ${url}`, async () => {
+    assert.equal(await isUrlSafe(url), false);
+  });
+}
+
+// Hostname forms that should never reach the network.
+const UNSAFE_NAMES = [
+  'http://localhost/',
+  'http://localhost:9117/',
+  'http://foo.local/',
+  'http://service.internal/',
+  'http://metadata.google.internal/',
+];
+
+for (const url of UNSAFE_NAMES) {
+  test(`isUrlSafe rejects internal hostname: ${url}`, async () => {
+    assert.equal(await isUrlSafe(url), false);
+  });
+}
+
+// Non-HTTP schemes and malformed input.
+const REJECTED_INPUT = [
+  'ftp://example.com/',
+  'file:///etc/passwd',
+  'gopher://127.0.0.1/',
+  'not a url',
+  '',
+];
+
+for (const url of REJECTED_INPUT) {
+  test(`isUrlSafe rejects non-HTTP or malformed input: ${JSON.stringify(url)}`, async () => {
+    assert.equal(await isUrlSafe(url), false);
+  });
+}
+
+// Public IP literals must still be allowed (these need no DNS lookup).
+const SAFE_URLS = [
+  'http://1.1.1.1/',
+  'https://8.8.8.8/',
+  'https://93.184.216.34:9117/torznab/api',
+  'http://172.15.0.1/',   // just below the 172.16.0.0/12 block
+  'http://172.32.0.1/',   // just above it
+  'http://11.0.0.1/',     // adjacent to 10.0.0.0/8
+  'http://126.255.255.255/', // just below 127.0.0.0/8
+  'http://128.0.0.1/',    // just above it
+  'http://[2606:4700:4700::1111]/',
+  'http://[2a00:1450:4001:800::200e]/',
+];
+
+for (const url of SAFE_URLS) {
+  test(`isUrlSafe allows public address: ${url}`, async () => {
+    assert.equal(await isUrlSafe(url), true);
+  });
+}
+
+// Direct range-boundary checks on the classifier.
+test('isPrivateIp flags private and reserved IPv4 ranges', () => {
+  for (const ip of ['0.0.0.0', '10.0.0.1', '100.64.0.0', '100.127.255.255',
+    '127.0.0.1', '169.254.169.254', '172.16.0.0', '172.31.255.255',
+    '192.168.0.1', '198.18.0.1', '224.0.0.1', '255.255.255.255']) {
+    assert.equal(isPrivateIp(ip), true, `${ip} should be private`);
+  }
+});
+
+test('isPrivateIp allows public IPv4 just outside each range', () => {
+  for (const ip of ['1.1.1.1', '8.8.8.8', '100.63.255.255', '100.128.0.0',
+    '172.15.255.255', '172.32.0.0', '192.167.255.255', '192.169.0.0',
+    '198.17.255.255', '198.20.0.0', '223.255.255.255']) {
+    assert.equal(isPrivateIp(ip), false, `${ip} should be public`);
+  }
+});
+
+test('isPrivateIp flags internal IPv6 and IPv4-mapped forms', () => {
+  for (const ip of ['::1', '::', '::ffff:127.0.0.1', '::ffff:7f00:1',
+    '::ffff:10.0.0.1', 'fe80::1', 'fc00::1', 'fd00::1', 'ff02::1']) {
+    assert.equal(isPrivateIp(ip), true, `${ip} should be private`);
+  }
+});
+
+test('isPrivateIp allows public IPv6', () => {
+  for (const ip of ['2606:4700:4700::1111', '2a00:1450:4001:800::200e']) {
+    assert.equal(isPrivateIp(ip), false, `${ip} should be public`);
+  }
+});


### PR DESCRIPTION
## Why

The Torznab provider validates the user-supplied `torznabUrl` config through `isUrlSafe` before the scraper fetches it. The old guard matched the hostname as a string, which misses internal addresses written in non-dotted encodings that still resolve to internal hosts:

- decimal / hex / octal IPv4, e.g. `http://2130706433/`, `http://0x7f000001/`, `http://0177.0.0.1/` (all `127.0.0.1`)
- bracketed IPv6 literals, e.g. `http://[::1]/` (the check compared against `'::1'`, but `URL.hostname` returns `'[::1]'`)
- IPv4-mapped IPv6, e.g. `http://[::ffff:127.0.0.1]/` and `http://[::ffff:169.254.169.254]/`

The bracketed and IPv4-mapped forms bypassed the guard outright, so anyone able to set the Torznab URL could point the scraper at loopback, private, link-local or cloud-metadata endpoints (SSRF).

This was noticed while looking at the `ip@2.0.1` dependabot alert but is unrelated to that dependency: it is a pre-existing gap in the hand-rolled guard.

## How

- Range-check the actual address bytes instead of the hostname string. Literal IPs in any encoding are classified directly against private and reserved IPv4/IPv6 ranges (loopback, RFC 1918, CGNAT, link-local, IETF/benchmark/multicast/reserved; IPv6 `::1`, `fc00::/7`, `fe80::/10`, `ff00::/8`, `2001:db8::/32`, and IPv4-mapped/compatible forms decoded to their embedded IPv4).
- Real hostnames are resolved via `dns.lookup(..., { all: true })` and every answer is checked, failing closed on lookup error or a 5s timeout.
- Uses only `node:net` and `node:dns`. Does **not** reintroduce the `ip` package (open advisory, and its classifiers are themselves bypassable by these encodings).
- `isUrlSafe` is now `async`; the single caller in `scrape` awaits it.

### Known limitation (follow-up)

This validates the resolved IP at check time, but the axios fetch re-resolves DNS at connect time, so active DNS rebinding is not fully defeated. Closing that needs the resolved IP pinned at connect time in the shared HTTP client, which is a separate change to `scraper/lib/httpClient.js`.

## Tests

New `scraper/test/torznab-ssrf.test.js` covers decimal/hex/octal loopback and private encodings, IPv4-mapped and IPv4-compatible IPv6, IPv6 internal ranges, internal hostnames, non-HTTP schemes, and public-address allow cases (including range boundaries such as 172.15 vs 172.16 vs 172.31 vs 172.32 and 100.63 vs 100.64 vs 100.128).

```
cd scraper && node --test
```

54 pass, 0 fail (52 new + the 2 existing domain-rotation tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)