### PR TITLE
Pin verified IP for Torznab requests to close DNS-rebinding SSRF

### DIFF
--- a/scraper/lib/httpClient.js
+++ b/scraper/lib/httpClient.js
@@ -1,3 +1,5 @@
+import http from 'node:http';
+import https from 'node:https';
 import axios from 'axios';
 import Bottleneck from 'bottleneck';
 
@@ -30,6 +32,12 @@ function getLimiter(key) {
  * @param {number}  opts.timeout       Request timeout ms (default 12000)
  * @param {string}  opts.responseType  axios responseType (default 'text')
  * @param {number}  opts.retries       Retry count on 5xx / network error (default 2)
+ * @param {Function} opts.lookup       Custom DNS lookup for SSRF-safe requests.
+ *                                     When set, the connection is pinned to the
+ *                                     address this lookup returns and redirects
+ *                                     are disabled (see lib/ssrf.js). The URL
+ *                                     still carries the hostname, so the Host
+ *                                     header and TLS SNI are preserved.
  */
 export async function get(url, {
   limiterKey = 'default',
@@ -38,8 +46,22 @@ export async function get(url, {
   timeout = 12000,
   responseType = 'text',
   retries = 2,
+  lookup = null,
 } = {}) {
   const limiter = getLimiter(limiterKey);
+
+  // A pinned lookup routes the socket to a pre-validated IP. Disable redirects
+  // (maxRedirects: 0) so a 3xx to another host can't escape the pinned target;
+  // this also makes axios use the raw http/https transport, which honours the
+  // agent's lookup. Agents are non-keep-alive so no socket outlives the request.
+  const pinned = typeof lookup === 'function';
+  const safe = pinned
+    ? {
+        httpAgent: new http.Agent({ lookup, keepAlive: false }),
+        httpsAgent: new https.Agent({ lookup, keepAlive: false }),
+        maxRedirects: 0,
+      }
+    : {};
 
   return limiter.schedule(async () => {
     let lastErr;
@@ -50,6 +72,7 @@ export async function get(url, {
           headers: { ...DEFAULT_HEADERS, ...headers },
           timeout,
           responseType,
+          ...safe,
         });
         return res;
       } catch (err) {

--- a/scraper/lib/ssrf.js
+++ b/scraper/lib/ssrf.js
@@ -1,0 +1,234 @@
+/**
+ * SSRF protection for user-supplied URLs (currently the Torznab base URL).
+ *
+ * The guard does two things:
+ *   1. Resolves the hostname and range-checks every resolved IP against the
+ *      private / reserved ranges (the "check").
+ *   2. Returns a pinned `lookup` bound to the exact IP it just validated, so the
+ *      socket connects to that same address (the "use").
+ *
+ * Pinning the verified IP closes the DNS-rebinding window: without it the
+ * hostname is resolved once for validation and a second time by the HTTP client
+ * at connect time, and an attacker controlling DNS could return a public IP for
+ * the first lookup and a private one for the second (classic TOCTOU rebinding).
+ *
+ * Only Node built-ins are used (node:net / node:dns); no third-party IP parser.
+ */
+import net from 'node:net';
+import dns from 'node:dns';
+
+// ─── IPv4 helpers ───────────────────────────────────────────────────────────
+
+function ipv4ToInt(ip) {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return null;
+  let n = 0;
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const octet = Number(part);
+    if (octet > 255) return null;
+    n = n * 256 + octet;
+  }
+  return n >>> 0;
+}
+
+function inCidrV4(n, baseStr, bits) {
+  const base = ipv4ToInt(baseStr);
+  const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+  return (n & mask) === (base & mask);
+}
+
+// Private, loopback, link-local (incl. cloud metadata 169.254.169.254), CGNAT,
+// broadcast, multicast, documentation and otherwise reserved IPv4 ranges.
+const UNSAFE_V4 = [
+  ['0.0.0.0', 8], ['10.0.0.0', 8], ['100.64.0.0', 10], ['127.0.0.0', 8],
+  ['169.254.0.0', 16], ['172.16.0.0', 12], ['192.0.0.0', 24], ['192.0.2.0', 24],
+  ['192.88.99.0', 24], ['192.168.0.0', 16], ['198.18.0.0', 15], ['198.51.100.0', 24],
+  ['203.0.113.0', 24], ['224.0.0.0', 4], ['240.0.0.0', 4],
+];
+
+function isUnsafeV4(n) {
+  if (n === null) return true;
+  return UNSAFE_V4.some(([base, bits]) => inCidrV4(n, base, bits));
+}
+
+// ─── IPv6 helpers ───────────────────────────────────────────────────────────
+
+/** Expand any valid IPv6 text form (incl. embedded IPv4) to 16 bytes, else null. */
+function ipv6ToBytes(input) {
+  let ip = input.split('%')[0]; // drop zone id, e.g. fe80::1%eth0
+
+  // Fold a trailing embedded IPv4 (::ffff:1.2.3.4, ::1.2.3.4) into two hextets.
+  if (ip.includes('.')) {
+    const lastColon = ip.lastIndexOf(':');
+    if (lastColon === -1) return null;
+    const v4 = ipv4ToInt(ip.slice(lastColon + 1));
+    if (v4 === null) return null;
+    const hi = ((v4 >>> 16) & 0xffff).toString(16);
+    const lo = (v4 & 0xffff).toString(16);
+    ip = ip.slice(0, lastColon + 1) + hi + ':' + lo;
+  }
+
+  const halves = ip.split('::');
+  if (halves.length > 2) return null;
+
+  const toGroups = (str) => (str === '' ? [] : str.split(':'));
+  const head = toGroups(halves[0]);
+  const tail = halves.length === 2 ? toGroups(halves[1]) : null;
+
+  let groups;
+  if (tail === null) {
+    groups = head;
+  } else {
+    const missing = 8 - (head.length + tail.length);
+    if (missing < 1) return null; // '::' must stand for at least one group
+    groups = [...head, ...Array(missing).fill('0'), ...tail];
+  }
+  if (groups.length !== 8) return null;
+
+  const bytes = new Uint8Array(16);
+  for (let i = 0; i < 8; i++) {
+    if (!/^[0-9a-fA-F]{1,4}$/.test(groups[i])) return null;
+    const value = parseInt(groups[i], 16);
+    bytes[i * 2] = (value >> 8) & 0xff;
+    bytes[i * 2 + 1] = value & 0xff;
+  }
+  return bytes;
+}
+
+function allZero(bytes, start, end) {
+  for (let i = start; i < end; i++) if (bytes[i] !== 0) return false;
+  return true;
+}
+
+function bytesToV4Int(bytes, offset) {
+  return ((bytes[offset] << 24) | (bytes[offset + 1] << 16) |
+          (bytes[offset + 2] << 8) | bytes[offset + 3]) >>> 0;
+}
+
+function isUnsafeV6(bytes) {
+  // IPv4-mapped ::ffff:a.b.c.d, so validate the embedded IPv4.
+  if (allZero(bytes, 0, 10) && bytes[10] === 0xff && bytes[11] === 0xff) {
+    return isUnsafeV4(bytesToV4Int(bytes, 12));
+  }
+  // IPv4-compatible / low addresses ::a.b.c.d (top 96 bits zero) incl. :: and ::1.
+  if (allZero(bytes, 0, 12)) {
+    return isUnsafeV4(bytesToV4Int(bytes, 12));
+  }
+  if (bytes[0] === 0xfe && (bytes[1] & 0xc0) === 0x80) return true; // fe80::/10 link-local
+  if ((bytes[0] & 0xfe) === 0xfc) return true;                      // fc00::/7 unique-local
+  if (bytes[0] === 0xff) return true;                              // ff00::/8 multicast
+  // 2001:db8::/32 documentation
+  if (bytes[0] === 0x20 && bytes[1] === 0x01 && bytes[2] === 0x0d && bytes[3] === 0xb8) return true;
+  return false;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * True when `ip` is not a globally-routable unicast address, i.e. it falls in a
+ * private, loopback, link-local, CGNAT, multicast, reserved or documentation
+ * range (or is not a valid IP at all). Unknown / unparseable input is unsafe.
+ */
+export function isPrivateOrReservedIp(ip) {
+  const kind = net.isIP(ip);
+  if (kind === 4) return isUnsafeV4(ipv4ToInt(ip));
+  if (kind === 6) {
+    const bytes = ipv6ToBytes(ip);
+    return bytes === null ? true : isUnsafeV6(bytes);
+  }
+  return true;
+}
+
+/**
+ * Build a Node `lookup(hostname, options, callback)` that always resolves to a
+ * single pre-validated IP, regardless of what DNS would return. Re-checks the
+ * address on every call as defense-in-depth, so it can never hand a
+ * private/reserved IP to the socket even if reused for another host.
+ */
+export function pinnedLookup(address, family) {
+  const fam = family || net.isIP(address) || 4;
+  return function lookup(hostname, options, callback) {
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+    if (isPrivateOrReservedIp(address)) {
+      const err = new Error(`Blocked connection to private or reserved address ${address}`);
+      err.code = 'EAI_BLOCKED';
+      callback(err);
+      return;
+    }
+    // Node may request the full list (options.all, used by autoSelectFamily).
+    if (options.all) callback(null, [{ address, family: fam }]);
+    else callback(null, address, fam);
+  };
+}
+
+/**
+ * Validate a user-supplied URL and pin the IP the request must connect to.
+ *
+ * Returns `{ url, hostname, address, family, lookup }` when the URL is http(s),
+ * resolves, and every resolved address is public; otherwise `null`. Pass the
+ * returned `lookup` to the HTTP client so it connects to `address` while still
+ * sending the original hostname (Host header + TLS SNI stay intact).
+ *
+ * @param {string} urlStr
+ * @param {object} [opts]
+ * @param {(host: string, options: object) => Promise<Array<{address: string, family: number}>>} [opts.dnsLookup]
+ *        DNS resolver override (defaults to dns.promises.lookup); injectable for tests.
+ */
+export async function resolveSafeTarget(urlStr, opts = {}) {
+  let url;
+  try {
+    url = new URL(urlStr);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+
+  const hostname = url.hostname;
+  if (!hostname) return null;
+
+  // Cheap denials for obvious internal names. The DNS-resolved IP check below is
+  // authoritative; these just reject before touching the resolver.
+  const lower = hostname.toLowerCase();
+  if (
+    lower === 'localhost' ||
+    lower.endsWith('.localhost') ||
+    lower.endsWith('.local') ||
+    lower.endsWith('.internal')
+  ) {
+    return null;
+  }
+
+  // URL keeps IPv6 literals bracketed ([::1]); net/dns want them unbracketed.
+  const host = hostname.replace(/^\[|\]$/g, '');
+
+  const dnsLookup = opts.dnsLookup || ((h, o) => dns.promises.lookup(h, o));
+
+  let addresses;
+  try {
+    addresses = await dnsLookup(host, { all: true });
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(addresses) || addresses.length === 0) return null;
+
+  // Reject if ANY resolved address is unsafe: DNS round-robin could otherwise
+  // hand a private record to the socket even when the first one looked public.
+  for (const entry of addresses) {
+    if (!entry || isPrivateOrReservedIp(entry.address)) return null;
+  }
+
+  const chosen = addresses[0];
+  return {
+    url,
+    hostname,
+    address: chosen.address,
+    family: chosen.family,
+    lookup: pinnedLookup(chosen.address, chosen.family),
+  };
+}

--- a/scraper/lib/ssrf.js
+++ b/scraper/lib/ssrf.js
@@ -17,6 +17,18 @@
 import net from 'node:net';
 import dns from 'node:dns';
 
+const DNS_TIMEOUT_MS = 5_000;
+
+/** Reject `promise` if it does not settle within `ms`, so DNS cannot stall us. */
+function withTimeout(promise, ms) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error('dns timeout')), ms);
+    timer.unref?.();
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
 // ─── IPv4 helpers ───────────────────────────────────────────────────────────
 
 function ipv4ToInt(ip) {
@@ -178,6 +190,9 @@ export function pinnedLookup(address, family) {
  * @param {object} [opts]
  * @param {(host: string, options: object) => Promise<Array<{address: string, family: number}>>} [opts.dnsLookup]
  *        DNS resolver override (defaults to dns.promises.lookup); injectable for tests.
+ * @param {number} [opts.dnsTimeoutMs]
+ *        Hard cap on the DNS resolution (default 5000ms); a slow/hostile resolver
+ *        fails closed instead of stalling the request.
  */
 export async function resolveSafeTarget(urlStr, opts = {}) {
   let url;
@@ -208,10 +223,11 @@ export async function resolveSafeTarget(urlStr, opts = {}) {
   const host = hostname.replace(/^\[|\]$/g, '');
 
   const dnsLookup = opts.dnsLookup || ((h, o) => dns.promises.lookup(h, o));
+  const dnsTimeoutMs = opts.dnsTimeoutMs ?? DNS_TIMEOUT_MS;
 
   let addresses;
   try {
-    addresses = await dnsLookup(host, { all: true });
+    addresses = await withTimeout(dnsLookup(host, { all: true }), dnsTimeoutMs);
   } catch {
     return null;
   }

--- a/scraper/providers/torznab.js
+++ b/scraper/providers/torznab.js
@@ -4,6 +4,7 @@
  */
 import * as cheerio from 'cheerio';
 import { get } from '../lib/httpClient.js';
+import { resolveSafeTarget } from '../lib/ssrf.js';
 import { parseTitle, buildSearchQuery } from '../lib/titleHelper.js';
 import { logger } from '../lib/logger.js';
 
@@ -18,7 +19,10 @@ export async function scrape(meta) {
   const apiKey  = meta.torznabApiKey;
   if (!baseUrl) return [];
 
-  if (!isUrlSafe(baseUrl)) {
+  // Resolve + validate the user-supplied URL and pin the verified IP so the
+  // request connects to exactly that address (closes the DNS-rebinding window).
+  const target = await resolveSafeTarget(baseUrl);
+  if (!target) {
     logger.warn('[Torznab] Rejected unsafe or invalid URL');
     return [];
   }
@@ -30,6 +34,7 @@ export async function scrape(meta) {
       limiterKey: 'torznab',
       timeout: 15_000,
       params,
+      lookup: target.lookup,
     });
 
     const $ = cheerio.load(data, { xmlMode: true });
@@ -125,24 +130,6 @@ function extractInfoHash(item) {
 function attrValue(item, attrName) {
   const el = item.find(`torznab\\:attr[name="${attrName}"], attr[name="${attrName}"]`);
   return el.length ? el.attr('value') : null;
-}
-
-function isUrlSafe(urlStr) {
-  try {
-    const parsed = new URL(urlStr);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
-    const host = parsed.hostname;
-    if (host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '0.0.0.0') return false;
-    if (host.startsWith('10.')) return false;
-    if (host.startsWith('192.168.')) return false;
-    if (host.startsWith('169.254.')) return false;
-    if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return false;
-    if (host.endsWith('.local') || host.endsWith('.internal')) return false;
-    if (host.includes('metadata.google') || host.includes('metadata.aws')) return false;
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 function base32ToHex(base32) {

--- a/scraper/test/httpClient-pinning.test.js
+++ b/scraper/test/httpClient-pinning.test.js
@@ -1,0 +1,110 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+
+import { get } from '../lib/httpClient.js';
+
+// A pinned lookup that forces every hostname to the loopback test server,
+// mirroring what lib/ssrf.js hands to the client (but pointing at 127.0.0.1 so
+// the test needs no real network). Handles the options.all shape Node uses.
+function pinToLoopback() {
+  return (hostname, options, callback) => {
+    if (typeof options === 'function') { callback = options; options = {}; }
+    if (options && options.all) callback(null, [{ address: '127.0.0.1', family: 4 }]);
+    else callback(null, '127.0.0.1', 4);
+  };
+}
+
+function listen(server) {
+  return new Promise((resolve) => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+function close(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+test('pinned lookup connects to the pinned IP while preserving the Host header', async () => {
+  const received = [];
+  const server = http.createServer((req, res) => {
+    received.push({ host: req.headers.host, url: req.url });
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('ok');
+  });
+  const port = await listen(server);
+
+  try {
+    // `blocked.invalid` never resolves in real DNS; the request only succeeds
+    // because the pinned lookup routes the socket to 127.0.0.1.
+    const res = await get(`http://blocked.invalid:${port}/torznab/api`, {
+      limiterKey: `pin-${port}`,
+      retries: 0,
+      params: { t: 'search', q: 'x' },
+      lookup: pinToLoopback(),
+    });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.data, 'ok');
+    assert.equal(received.length, 1);
+    // Host header carries the original hostname + port, not the connect IP.
+    assert.equal(received[0].host, `blocked.invalid:${port}`);
+    assert.equal(received[0].url, '/torznab/api?t=search&q=x');
+  } finally {
+    await close(server);
+  }
+});
+
+test('pinned lookup disables redirects (a 3xx does not reach another host)', async () => {
+  let hits = 0;
+  const server = http.createServer((req, res) => {
+    hits++;
+    // Try to bounce the client to an internal target.
+    res.writeHead(302, { Location: 'http://169.254.169.254/latest/meta-data/' });
+    res.end();
+  });
+  const port = await listen(server);
+
+  try {
+    await assert.rejects(
+      get(`http://target.invalid:${port}/`, {
+        limiterKey: `redir-${port}`,
+        retries: 0,
+        lookup: pinToLoopback(),
+      }),
+      (err) => {
+        // maxRedirects: 0 -> the 302 is surfaced as an error, never followed.
+        assert.equal(err.response?.status, 302);
+        return true;
+      },
+    );
+    assert.equal(hits, 1, 'redirect target must not be requested');
+  } finally {
+    await close(server);
+  }
+});
+
+test('requests without a lookup are unaffected (normal redirect following)', async () => {
+  let hits = 0;
+  const server = http.createServer((req, res) => {
+    hits++;
+    if (req.url === '/start') {
+      res.writeHead(302, { Location: '/final' });
+      res.end();
+    } else {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('landed');
+    }
+  });
+  const port = await listen(server);
+
+  try {
+    const res = await get(`http://127.0.0.1:${port}/start`, {
+      limiterKey: `noredir-${port}`,
+      retries: 0,
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.data, 'landed');
+    assert.equal(hits, 2, 'default path should follow the redirect');
+  } finally {
+    await close(server);
+  }
+});

--- a/scraper/test/ssrf.test.js
+++ b/scraper/test/ssrf.test.js
@@ -124,6 +124,34 @@ test('resolveSafeTarget rejects private IP literals (no network)', async () => {
   }
 });
 
+test('resolveSafeTarget rejects encoded-integer IP hosts (decimal/hex/octal/short)', async () => {
+  // WHATWG new URL() canonicalises these numeric forms to dotted-decimal
+  // (127.0.0.1 / 192.168.0.1), which the range check then rejects. All are
+  // numeric hosts, so dns.lookup short-circuits and no network is touched.
+  for (const url of [
+    'http://2130706433/',   // decimal 127.0.0.1
+    'http://0x7f000001/',   // hex 127.0.0.1
+    'http://0177.0.0.1/',   // octal first octet -> 127.0.0.1
+    'http://127.1/',        // short form -> 127.0.0.1
+    'http://3232235521/',   // decimal 192.168.0.1
+    'http://0xC0A80001/',   // hex 192.168.0.1
+  ]) {
+    assert.equal(await resolveSafeTarget(url), null, url);
+  }
+});
+
+test('resolveSafeTarget fails closed when DNS resolution is too slow', async () => {
+  // Resolver that only answers after the timeout window. It still settles (so
+  // no promise leaks in the test runner), but resolveSafeTarget must give up
+  // first and return null.
+  const slow = () =>
+    new Promise((resolve) => setTimeout(() => resolve([{ address: '8.8.8.8', family: 4 }]), 60));
+  assert.equal(
+    await resolveSafeTarget('http://slow-resolver.example/', { dnsLookup: slow, dnsTimeoutMs: 20 }),
+    null,
+  );
+});
+
 test('resolveSafeTarget accepts a public IP literal and pins it', async () => {
   const target = await resolveSafeTarget('http://8.8.8.8:9117/api');
   assert.ok(target);

--- a/scraper/test/ssrf.test.js
+++ b/scraper/test/ssrf.test.js
@@ -1,0 +1,180 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  isPrivateOrReservedIp,
+  pinnedLookup,
+  resolveSafeTarget,
+} from '../lib/ssrf.js';
+
+// Promisified pinnedLookup helpers for assertions.
+function callLookup(lookup, options = {}) {
+  return new Promise((resolve, reject) => {
+    lookup('any-host.example', options, (err, address, family) => {
+      if (err) reject(err);
+      else resolve({ address, family });
+    });
+  });
+}
+
+// ─── isPrivateOrReservedIp ─────────────────────────────────────────────────────
+
+test('isPrivateOrReservedIp flags private / reserved IPv4', () => {
+  for (const ip of [
+    '0.0.0.0', '10.0.0.1', '10.255.255.255', '100.64.0.1', '127.0.0.1',
+    '169.254.169.254', '172.16.0.1', '172.31.255.255', '192.0.2.1',
+    '192.168.1.1', '198.18.0.5', '198.51.100.7', '203.0.113.9',
+    '224.0.0.1', '240.0.0.1', '255.255.255.255',
+  ]) {
+    assert.equal(isPrivateOrReservedIp(ip), true, `${ip} should be unsafe`);
+  }
+});
+
+test('isPrivateOrReservedIp allows public IPv4', () => {
+  for (const ip of [
+    '8.8.8.8', '1.1.1.1', '93.184.216.34',
+    '172.15.255.255', '172.32.0.1', '100.63.255.255', '11.0.0.1',
+  ]) {
+    assert.equal(isPrivateOrReservedIp(ip), false, `${ip} should be safe`);
+  }
+});
+
+test('isPrivateOrReservedIp flags private / reserved IPv6', () => {
+  for (const ip of [
+    '::1', '::', 'fe80::1', 'fc00::1', 'fd12:3456::1', 'ff02::1',
+    '2001:db8::1', '::ffff:127.0.0.1', '::ffff:10.0.0.1', '::ffff:169.254.169.254',
+  ]) {
+    assert.equal(isPrivateOrReservedIp(ip), true, `${ip} should be unsafe`);
+  }
+});
+
+test('isPrivateOrReservedIp allows public IPv6', () => {
+  for (const ip of ['2606:4700:4700::1111', '2001:4860:4860::8888', '::ffff:8.8.8.8']) {
+    assert.equal(isPrivateOrReservedIp(ip), false, `${ip} should be safe`);
+  }
+});
+
+test('isPrivateOrReservedIp treats non-IP input as unsafe', () => {
+  for (const value of ['', 'not-an-ip', 'example.com', '999.1.1.1', '::gggg']) {
+    assert.equal(isPrivateOrReservedIp(value), true, `${value} should be unsafe`);
+  }
+});
+
+// ─── pinnedLookup ──────────────────────────────────────────────────────────────
+
+test('pinnedLookup returns the pinned address for all callback shapes', async () => {
+  const lookup = pinnedLookup('8.8.8.8', 4);
+
+  assert.deepEqual(await callLookup(lookup, {}), { address: '8.8.8.8', family: 4 });
+  assert.deepEqual(await callLookup(lookup, { family: 4 }), { address: '8.8.8.8', family: 4 });
+
+  // options.all -> array form (used by autoSelectFamily)
+  const all = await new Promise((resolve, reject) =>
+    lookup('h', { all: true }, (err, addrs) => (err ? reject(err) : resolve(addrs))));
+  assert.deepEqual(all, [{ address: '8.8.8.8', family: 4 }]);
+
+  // options omitted -> (hostname, callback)
+  const short = await new Promise((resolve, reject) =>
+    lookup('h', (err, address, family) => (err ? reject(err) : resolve({ address, family }))));
+  assert.deepEqual(short, { address: '8.8.8.8', family: 4 });
+});
+
+test('pinnedLookup derives IPv6 family and returns it', async () => {
+  const lookup = pinnedLookup('2606:4700:4700::1111');
+  assert.deepEqual(await callLookup(lookup, {}), { address: '2606:4700:4700::1111', family: 6 });
+});
+
+test('pinnedLookup refuses to hand out a private address (defense in depth)', async () => {
+  const lookup = pinnedLookup('10.0.0.1', 4);
+  await assert.rejects(callLookup(lookup, {}), (err) => {
+    assert.equal(err.code, 'EAI_BLOCKED');
+    return true;
+  });
+});
+
+// ─── resolveSafeTarget ─────────────────────────────────────────────────────────
+
+test('resolveSafeTarget rejects non-http(s) protocols', async () => {
+  for (const url of ['ftp://example.com/', 'file:///etc/passwd', 'gopher://x/']) {
+    assert.equal(await resolveSafeTarget(url), null, url);
+  }
+});
+
+test('resolveSafeTarget rejects malformed URLs', async () => {
+  assert.equal(await resolveSafeTarget('not a url'), null);
+  assert.equal(await resolveSafeTarget(''), null);
+});
+
+test('resolveSafeTarget rejects internal hostnames without resolving', async () => {
+  const explode = () => { throw new Error('resolver must not be called'); };
+  for (const url of [
+    'http://localhost/', 'http://LOCALHOST:9117/', 'http://box.local/',
+    'http://svc.internal/', 'http://app.localhost/',
+  ]) {
+    assert.equal(await resolveSafeTarget(url, { dnsLookup: explode }), null, url);
+  }
+});
+
+test('resolveSafeTarget rejects private IP literals (no network)', async () => {
+  for (const url of [
+    'http://127.0.0.1:9117/', 'http://169.254.169.254/latest/meta-data/',
+    'http://10.0.0.5/', 'http://[::1]/', 'http://[fd00::1]/',
+  ]) {
+    assert.equal(await resolveSafeTarget(url), null, url);
+  }
+});
+
+test('resolveSafeTarget accepts a public IP literal and pins it', async () => {
+  const target = await resolveSafeTarget('http://8.8.8.8:9117/api');
+  assert.ok(target);
+  assert.equal(target.address, '8.8.8.8');
+  assert.equal(target.hostname, '8.8.8.8');
+  assert.equal(typeof target.lookup, 'function');
+});
+
+test('resolveSafeTarget pins the validated IP even if DNS later rebinds', async () => {
+  // Simulate the check returning a public address...
+  const target = await resolveSafeTarget('http://scanner.example/api', {
+    dnsLookup: async () => [{ address: '93.184.216.34', family: 4 }],
+  });
+  assert.ok(target);
+  assert.equal(target.address, '93.184.216.34');
+
+  // ...and confirm the pinned lookup keeps returning that same address (it does
+  // NOT re-resolve), so a rebind to a private IP at connect time cannot happen.
+  const resolved = await callLookup(target.lookup, { all: false });
+  assert.deepEqual(resolved, { address: '93.184.216.34', family: 4 });
+});
+
+test('resolveSafeTarget rejects when DNS resolves to a private address', async () => {
+  const target = await resolveSafeTarget('http://rebind.example/api', {
+    dnsLookup: async () => [{ address: '127.0.0.1', family: 4 }],
+  });
+  assert.equal(target, null);
+});
+
+test('resolveSafeTarget rejects when ANY resolved address is private', async () => {
+  const target = await resolveSafeTarget('http://mixed.example/api', {
+    dnsLookup: async () => [
+      { address: '93.184.216.34', family: 4 },
+      { address: '10.0.0.1', family: 4 },
+    ],
+  });
+  assert.equal(target, null);
+});
+
+test('resolveSafeTarget rejects an IPv4-mapped private address', async () => {
+  const target = await resolveSafeTarget('http://mapped.example/api', {
+    dnsLookup: async () => [{ address: '::ffff:169.254.169.254', family: 6 }],
+  });
+  assert.equal(target, null);
+});
+
+test('resolveSafeTarget returns null on resolver failure or empty result', async () => {
+  assert.equal(await resolveSafeTarget('http://nxdomain.example/', {
+    dnsLookup: async () => { throw Object.assign(new Error('nope'), { code: 'ENOTFOUND' }); },
+  }), null);
+  assert.equal(await resolveSafeTarget('http://empty.example/', {
+    dnsLookup: async () => [],
+  }), null);
+});


### PR DESCRIPTION
## Why

The Torznab provider is the only scraper that fetches a user-controlled URL: `torznabUrl` comes straight from `req.query` (`scraper/index.js`). The old guard did string-only hostname checks, so a hostname resolving to an internal IP passed. And even a proper resolve-then-check leaves a time-of-check/time-of-use gap: axios re-resolves DNS when it actually connects, so DNS an attacker controls can answer with a public IP during validation and a private one at connect time (classic DNS rebinding), reaching `127.0.0.1`, cloud metadata `169.254.169.254`, `10.0.0.0/8`, and so on.

## How

Pin the exact IP that validation approved, so there is no second resolution to attack.

- **New `scraper/lib/ssrf.js`** (node:net / node:dns only, no `ip` package):
  - `isPrivateOrReservedIp(ip)` range-checks IPv4 and IPv6 against private, loopback, link-local (incl. metadata), CGNAT, multicast, documentation and reserved ranges, and unwraps IPv4-mapped IPv6 (`::ffff:127.0.0.1`). Unparseable input is unsafe.
  - `resolveSafeTarget(url)` validates the protocol, rejects obvious internal names, resolves every A/AAAA record, rejects if any is private, and returns a `lookup` pinned to the validated IP.
  - `pinnedLookup(address)` always returns that one IP (handling Node's `options.all` shape) and re-validates on every call as defense in depth.
- **`scraper/lib/httpClient.js`** gains one opt-in `lookup` option. When set it builds non-keep-alive http/https agents with that lookup and forces `maxRedirects: 0`. Because only DNS is overridden (the URL keeps the hostname), the **Host header and TLS SNI are preserved**. Non-pinned callers (every other provider) are byte-for-byte unchanged.
- **`scraper/providers/torznab.js`** now resolves, validates and pins the target, then passes `target.lookup` to `get`. The old `isUrlSafe` is removed.

`maxRedirects: 0` makes axios use the raw http/https transport (verified against the axios 1.19 source), which honors the agent's lookup; a custom lookup on an `https.Agent` pinning the connect IP was also verified empirically on Node 24.

## Tests

`node --test` in `scraper/`, 23 pass (2 pre-existing + 21 new):

- `test/ssrf.test.js`: IPv4/IPv6 classification matrix, pinned-lookup callback shapes and the defense-in-depth block, and `resolveSafeTarget` including a **rebinding simulation** (public at check, pin holds), rejection when DNS returns private, and mixed / IPv4-mapped-private cases.
- `test/httpClient-pinning.test.js`: a loopback server proves the request reaches the pinned IP while sending `Host: <original-hostname>`, that a 302 is **not** followed (redirect target never hit), and that lookup-less requests still follow redirects normally.

## Note / trade-off

Disabling redirects means a Torznab endpoint that answers the API path with a 3xx now fails (returns `[]`). Real Jackett/Prowlarr Torznab endpoints return XML directly, so legitimate use is unaffected, but flagging the deliberate trade-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
