### PR TITLE
Fix P2P streams not appearing on Stremio clients (#111)

### DIFF
--- a/addon/lib/streamInfo.js
+++ b/addon/lib/streamInfo.js
@@ -1,5 +1,6 @@
 import { getLanguageFlag, toSubtitleLanguageCode } from './languages.js';
 import { extractQuality } from './sort.js';
+import { getBestTrackers } from './magnetHelper.js';
 
 const ADDON_PREFIX = '⚡ Magnetio';
 
@@ -29,10 +30,13 @@ export function toStreamInfo(record, config) {
   const useProxy = config?.proxyStreams && baseUrl;
   const fileIdx = record.fileIdx ?? undefined;
 
+  // NOTE: only `title` is emitted, never `description`. Several Stremio clients
+  // (Windows 6.0.1-beta, Android/Google TV) silently drop stream objects that
+  // carry a `description` field, so the whole list renders empty. Torrentio and
+  // other working addons use `title` only. See issue #111 / PR #126.
   const stream = {
     name,
     title: description,
-    description,
     behaviorHints: {
       bingeGroup:      getBingeGroup(record, quality),
       filename:        filename || undefined,
@@ -47,12 +51,14 @@ export function toStreamInfo(record, config) {
     stream.url = `${baseUrl}/proxy/stream/${record.infoHash}/${fileIdx ?? 0}${proxyParams}`;
     stream.behaviorHints.notWebReady = true;
     const proxyLabel = config.proxyUrl ? '🛡️ VPN Proxy' : '🛡️ Privacy Proxy';
-    const proxyDesc = description + '\n' + proxyLabel;
-    stream.title = proxyDesc;
-    stream.description = proxyDesc;
+    stream.title = description + '\n' + proxyLabel;
   } else {
     stream.infoHash = record.infoHash;
     stream.fileIdx = fileIdx;
+    // Peer-discovery hints for the client's torrent engine. Restored after
+    // PR #124 accidentally removed buildSources() (regression of PR #118):
+    // without a `sources` array, P2P streams have no trackers/DHT to resolve.
+    stream.sources = buildSources(record);
   }
 
   if (record.subtitles?.length) {
@@ -63,6 +69,19 @@ export function toStreamInfo(record, config) {
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build the `sources` array for a P2P (infoHash) stream: a `dht:<infoHash>`
+ * entry followed by `tracker:<url>` entries. Matches the format Torrentio and
+ * other working addons emit so clients can discover peers. Any per-record
+ * trackers are merged with the shared best-tracker list and de-duplicated.
+ */
+function buildSources(record) {
+  const trackers = [...new Set([...(record.trackers ?? []), ...getBestTrackers()])]
+    .filter(tracker => tracker.startsWith('udp://') || tracker.startsWith('http://') || tracker.startsWith('https://'))
+    .map(tracker => `tracker:${tracker}`);
+  return [`dht:${record.infoHash}`, ...trackers];
+}
 
 function getBingeGroup(record, quality) {
   if (record.fileIdx != null) {

--- a/addon/test/sdk-upgrade.test.js
+++ b/addon/test/sdk-upgrade.test.js
@@ -224,10 +224,17 @@ test('stream info uses the Stremio-compatible infoHash contract and subtitle mat
 
   assert.equal(stream.infoHash, 'abcdef0123456789abcdef0123456789abcdef01');
   assert.equal(stream.fileIdx, undefined);
-  assert.equal(stream.sources, undefined);
   assert.equal(stream.behaviorHints.filename, 'Example.Release.1080p.WEB-DL.x265');
   assert.equal(stream.behaviorHints.videoSize, 2 * 1024 * 1024 * 1024);
-  assert.match(stream.description, /WEB-DL/);
+  // Descriptive text lives in `title`; `description` must NOT be emitted, or
+  // several Stremio clients drop the whole stream list (issue #111 / PR #126).
+  assert.match(stream.title, /WEB-DL/);
+  assert.equal(stream.description, undefined);
+  // P2P streams carry peer-discovery sources: dht first, then trackers
+  // (regression fix for PR #124 which removed buildSources()).
+  assert.ok(Array.isArray(stream.sources) && stream.sources.length >= 2);
+  assert.equal(stream.sources[0], 'dht:abcdef0123456789abcdef0123456789abcdef01');
+  assert.ok(stream.sources.includes('tracker:udp://tracker.example:1337/announce'));
 });
 
 test('OpenSubtitles API requests explicitly accept JSON responses', () => {


### PR DESCRIPTION
Fixes #111.

## Diagnosis

Users reported (#111) that Magnetio's P2P streams never appear on Android, Google TV, and the Windows 6.0.1-beta client, while Torrentio works on the same devices, even though the `/stream` endpoint returns valid JSON with results. I confirmed this against the **live** deployment and diffed Magnetio's stream object against Torrentio's for the same title (`tt0133093`). Two compounding bugs:

**1. `description` field makes clients drop the list.**
Every stream object carried a `description` (a duplicate of `title`). Several Stremio clients silently drop stream objects that include `description`, so the whole list renders empty. Torrentio and other working addons emit `title` only. This matches the independent finding in #126.

**2. Missing `sources` — a regression from #124.**
#118 added `sources: ["dht:<infoHash>", "tracker:<url>", …]` for peer discovery. #124 ("Fix stream integrations…") then deleted the `getBestTrackers` import, the `stream.sources = buildSources(record)` call, and the entire `buildSources()` function. The live response confirms it: **no `sources` at all**. Torrentio always includes them.

| field | Torrentio (works) | Magnetio before | Magnetio after |
|---|---|---|---|
| `title` | ✅ | ✅ | ✅ |
| `description` | ✗ | ⚠️ present | ✗ removed |
| `sources` | ✅ | ✗ missing | ✅ restored |

## Fix

- Stop emitting `description`; keep `title` (identical text).
- Restore `buildSources()` for the P2P path (`dht:` first, then `tracker:` entries, merged from per-record trackers + the shared best-tracker list).
- Update the stream-contract test to assert the corrected shape (title carries the text, no `description`, `sources` present with dht + tracker).

The corrected object now matches Torrentio's known-good shape exactly.

## Verification

- `node --test` in `addon/` — 39/39 pass.
- Live diff + local reproduction of the constructed object confirm `description` is gone and `sources` is present.

## Relationship to #126

This supersedes #126: it makes the same `description` change **and** fixes the `sources` regression **and** updates the test that #126 would otherwise have broken (`sdk-upgrade.test.js`). #126 can be closed in favor of this once merged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)