### PR TITLE
Restart native services on deploy so new code actually loads

### DIFF
--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -97,8 +97,13 @@ else
   sudo install -m 0644 deploy/systemd/docker-media-recovery.timer /etc/systemd/system/docker-media-recovery.timer
   sudo systemctl daemon-reload
   sudo systemctl enable --now docker-media-recovery.timer
-  sudo systemctl enable --now magnetio-scraper.service
-  sudo systemctl enable --now magnetio-addon.service
+  # `enable --now` only STARTS a stopped service; on an already-running service
+  # it is a no-op, so the freshly rsynced code would never load. Enable, then
+  # restart explicitly so each deploy actually picks up the new code. Scraper
+  # first (the addon depends on it via After=magnetio-scraper.service).
+  sudo systemctl enable magnetio-scraper.service magnetio-addon.service
+  sudo systemctl restart magnetio-scraper.service
+  sudo systemctl restart magnetio-addon.service
 fi
 
 curl --fail --retry 12 --retry-delay 5 --retry-connrefused http://127.0.0.1:8080/health


### PR DESCRIPTION
## Problem

I went to confirm the #111 P2P fix on the live site and found it isn't live — even a never-cached request returns the **old** stream shape (`description` present, no `sources`). The `deploy` job succeeds, rsyncs the code to `/home/peterdsp/magnetio-recovery`, and reinstalls deps, but the native branch of `deploy-production.sh` only runs:

```
systemctl enable --now magnetio-scraper.service
systemctl enable --now magnetio-addon.service
```

`enable --now` **only starts a stopped service** — on an already-running service it's a no-op. The units run `ExecStart=/usr/bin/node index.js` with `WorkingDirectory=/home/peterdsp/magnetio-recovery/{addon,scraper}`, so a restart *would* load the new code, but the deploy never restarts them. The health check passes (the old process is up), so the workflow reports success.

Net effect: production has been serving the code from the last real restart (the #124 media-disk recovery). **None of #131–#137 or #136 are actually live.**

## Fix

Enable the units, then `systemctl restart` them explicitly (scraper first, since the addon is ordered `After=magnetio-scraper.service`). `restart` also starts a stopped service, so first-deploy behaviour is unchanged. The docker branch already stops + rebuilds, so it wasn't affected.

## Effect of merging

The deploy triggered by this merge runs the **new** script, which restarts both services — bringing this fix **and** all the already-merged work (#137 stream visibility, #136 SSRF, etc.) live in one go.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)