### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Magnetio-v1.1.5-10b981?style=for-the-badge&labelColor=1a1a2e" alt="Magnetio Version" />
+  <img src="https://img.shields.io/badge/Magnetio-v1.2.0-10b981?style=for-the-badge&labelColor=1a1a2e" alt="Magnetio Version" />
   <img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=for-the-badge&labelColor=1a1a2e" alt="License" />
   <img src="https://img.shields.io/badge/node-%3E%3D18-brightgreen?style=for-the-badge&logo=node.js&labelColor=1a1a2e" alt="Node.js" />
   <img src="https://img.shields.io/badge/docker-ready-2496ed?style=for-the-badge&logo=docker&labelColor=1a1a2e" alt="Docker" />

--- a/addon/lib/manifest.js
+++ b/addon/lib/manifest.js
@@ -2,7 +2,7 @@ import { getManifestOverride } from './configuration.js';
 import { MochOptions } from '../moch/options.js';
 
 const ADDON_ID      = 'com.magnetio.addon';
-const ADDON_VERSION = '1.1.5';
+const ADDON_VERSION = '1.2.0';
 const ADDON_NAME    = 'Magnetio';
 const ASSET_BASE_URL = `${(process.env.ADDON_PUBLIC_URL || 'https://magnetio.peterdsp.dev').replace(/\/$/, '')}/static`;
 const ADDON_LOGO = `${ASSET_BASE_URL}/magnetio-logo.svg`;

--- a/addon/package-lock.json
+++ b/addon/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "magnetio-addon",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "magnetio-addon",
-      "version": "1.1.5",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@keyv/redis": "^5.1.6",

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magnetio-addon",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Magnetio - Advanced Stremio addon with multi-debrid support and torrent aggregation",
   "type": "module",
   "main": "index.js",

--- a/addon/serverless.js
+++ b/addon/serverless.js
@@ -147,7 +147,7 @@ router.get('/proxy/stream/:infoHash/:fileIdx', proxyStreamLimiter, async (req, r
 });
 
 router.get('/health', (_req, res) => {
-  res.json({ status: 'ok', service: 'Magnetio', version: '1.1.5' });
+  res.json({ status: 'ok', service: 'Magnetio', version: '1.2.0' });
 });
 
 router.get('/stats', (req, res, next) => {

--- a/scraper/index.js
+++ b/scraper/index.js
@@ -20,7 +20,7 @@ app.set('trust proxy', 1);
 // ─── Health ───────────────────────────────────────────────────────────────────
 
 app.get('/health', (_req, res) => {
-  res.json({ status: 'ok', service: 'magnetio-scraper', version: '1.1.5' });
+  res.json({ status: 'ok', service: 'magnetio-scraper', version: '1.2.0' });
 });
 
 // ─── Provider list ────────────────────────────────────────────────────────────

--- a/scraper/package-lock.json
+++ b/scraper/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "magnetio-scraper",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "magnetio-scraper",
-      "version": "1.1.5",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@keyv/redis": "^5.1.6",

--- a/scraper/package.json
+++ b/scraper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magnetio-scraper",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Magnetio in-house torrent scraper back-end",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
Bumps Magnetio to **v1.2.0** (minor: on-demand debrid streams shipped this cycle).

## What changed
Version strings only, no behavioral change:
- `addon/package.json` + `addon/package-lock.json` → 1.2.0
- `scraper/package.json` + `scraper/package-lock.json` → 1.2.0
- `addon/lib/manifest.js` `ADDON_VERSION` → 1.2.0 (the version Stremio reads)
- `addon/serverless.js` and `scraper/index.js` `/health` payloads → 1.2.0
- README version badge → v1.2.0

## Why 1.2.0 (minor)
Since v1.1.5 this cycle shipped a new backward-compatible feature plus fixes:
- On-demand debrid streams for providers without a bulk cache-check (#131)
- Fix P2P streams not appearing on Stremio clients (#137)
- Pin verified IP for Torznab requests to close DNS-rebinding SSRF (#136)
- SMART media drive monitoring on deploy (#130)
- Restart native services on deploy so new code actually loads (#138)

Tag `v1.2.0` will be created on the squash-merge commit once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)